### PR TITLE
Hannah/dropdown controls

### DIFF
--- a/react/src/components/Button.tsx
+++ b/react/src/components/Button.tsx
@@ -11,6 +11,7 @@ const Component = styled.button<ButtonProps>`
     box-sizing: border-box;
     display: flex;
     align-items: center;
+    height: 40px;
     text-align: center;
     font-family: ${props => props.theme.fontFamily.heading};
     padding: ${props => props.theme.space[3]} ${props => props.theme.space[4]};

--- a/react/src/components/Dropdown/Dropdown.styles.tsx
+++ b/react/src/components/Dropdown/Dropdown.styles.tsx
@@ -4,6 +4,12 @@ const Flex = styled.div`
     display: flex;
 `;
 
+export const Input = styled.input`
+    min-height: 45px;
+    border: none;
+    outline: none;
+    font-size: ${props => props.theme.fontSizes.s};
+`;
 export const Wrapper = styled(Flex)`
     min-height: 38px;
     flex-wrap: wrap;
@@ -44,10 +50,8 @@ export const List = styled.div`
     top: 200px;
     z-index: 1;
     /* Dropdown List Styling */
-
     > li {
         list-style-type: none;
-
         &:first-of-type {
             > button {
                 border-top: ${props => props.theme.borders.thin} ${props =>
@@ -56,12 +60,10 @@ export const List = styled.div`
                 border-top-right-radius: ${props => props.theme.radii.base};
             }
         }
-
         &:last-of-type > button {
           border-bottom-left-radius: ${props => props.theme.radii.base};
           border-bottom-right-radius: ${props => props.theme.radii.base};
         }
-
         button {
             display: flex;
             justify-content: space-between;
@@ -75,7 +77,6 @@ export const List = styled.div`
             text-align: left;
             border-left: ${props => props.theme.borders.thin} ${props => props.theme.colors.muted};
             border-right: ${props => props.theme.borders.thin} ${props => props.theme.colors.muted};
-
             &:hover {
                 cursor: pointer;
                 font-weight: bold;

--- a/react/src/components/Dropdown/Dropdown.styles.tsx
+++ b/react/src/components/Dropdown/Dropdown.styles.tsx
@@ -7,6 +7,8 @@ const Flex = styled.div`
 export const Wrapper = styled(Flex)`
     min-height: 38px;
     flex-wrap: wrap;
+    flex-grow: 0;
+    width: 200px;
 `;
 
 export const Header = styled(Flex)`

--- a/react/src/components/Dropdown/Dropdown.styles.tsx
+++ b/react/src/components/Dropdown/Dropdown.styles.tsx
@@ -9,6 +9,7 @@ export const Input = styled.input`
     border: none;
     outline: none;
     font-size: ${props => props.theme.fontSizes.s};
+    width: 70%;
 `;
 export const Wrapper = styled(Flex)`
     min-height: 38px;
@@ -28,7 +29,7 @@ export const Header = styled(Flex)`
     justify-content: space-between;
     align-items: center;
     cursor: pointer;
-    width: 100%;
+    width: inherit;
 `;
 
 export const Title = styled.p`

--- a/react/src/components/Dropdown/Dropdown.styles.tsx
+++ b/react/src/components/Dropdown/Dropdown.styles.tsx
@@ -36,11 +36,13 @@ export const List = styled.div`
     box-shadow: ${props => props.theme.boxShadow}
     padding: 0;
     margin: 0;
-    width: 100%;
+    width: inherit;
     margin-top: ${props => props.theme.space[4]};
     max-height: 100px;
     overflow: auto;
-
+    position: absolute;
+    top: 200px;
+    z-index: 1;
     /* Dropdown List Styling */
 
     > li {

--- a/react/src/components/Dropdown/Dropdown.tsx
+++ b/react/src/components/Dropdown/Dropdown.tsx
@@ -2,28 +2,28 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
 import { useClickAway } from '../../hooks';
 import { DropdownItem } from '../../types';
-import { Input, Header, List, Title, Wrapper } from './Dropdown.styles';
+import { Header, Input, List, Title, Wrapper } from './Dropdown.styles';
 
 interface DropdownProps {
     title: string;
     items: DropdownItem[];
-    onChange: (item: DropdownItem) => void;
-    reset?: Boolean;
+    onChange: (item: { value: string }) => void;
     multiSelect?: boolean;
     searchable?: boolean;
-    value?: string | number;
+    value?: string | string[];
 }
 
 const Dropdown: React.FC<DropdownProps> = ({
     items,
     multiSelect,
     title,
-    reset,
     searchable,
     value,
     onChange,
 }) => {
+    // Note: Currently, text is only usable for single-select autocomplete. More work needs to be done for multiSelect autocomplete....
     const [text, setText] = useState(value);
+    console.log(text, value);
     const [open, setOpen] = useState<Boolean>(false);
     const [selection, setSelection] = useState<DropdownItem[]>([]);
     const [suggestions, setSuggestions] = useState<DropdownItem[]>(items);
@@ -35,9 +35,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         setText(value);
         setOpen(true);
         onChange({
-            id: 1,
             value: value,
-            label: value,
         });
         if (value.length > 0) {
             const regex = new RegExp(`^${value}`, 'i');
@@ -49,7 +47,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     };
 
     function handleOnClick(item: DropdownItem) {
-        onChange(item);
+        onChange({ value: item.value });
         if (!selection.some(current => current.id === item.id)) {
             if (!multiSelect) {
                 setSelection([item]);
@@ -71,20 +69,18 @@ const Dropdown: React.FC<DropdownProps> = ({
     }
 
     useEffect(() => {
-        if (reset) {
-            setSelection([]);
-        }
-    }, [reset]);
-
-    useEffect(() => {
         if (searchable && selection.length > 0) {
+            // Autocomplete text based on the selection
             setText(selection[0].value);
         }
-    }, [selection]);
+    }, [selection, searchable]);
 
     useEffect(() => {
         setText(value);
-    }, [value]);
+        if (value === '' || value?.length === 0) {
+            setSelection([]);
+        }
+    }, [items, value]);
 
     const fragmentRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
     useClickAway(fragmentRef, () => setOpen(false));

--- a/react/src/components/Dropdown/Dropdown.tsx
+++ b/react/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
 import { useClickAway } from '../../hooks';
 import { DropdownItem } from '../../types';
@@ -10,13 +10,34 @@ interface DropdownProps {
     onChange: (item: DropdownItem) => void;
     reset?: Boolean;
     multiSelect?: boolean;
+    searchable?: boolean;
 }
 
-const Dropdown: React.FC<DropdownProps> = ({ items, multiSelect, title, reset, onChange }) => {
+const Dropdown: React.FC<DropdownProps> = ({
+    items,
+    multiSelect,
+    title,
+    reset,
+    searchable,
+    onChange,
+}) => {
     const [open, setOpen] = useState<Boolean>(false);
     const [selection, setSelection] = useState<DropdownItem[]>([]);
+    const [suggestions, setSuggestions] = useState<DropdownItem[]>(items);
+    console.log(suggestions);
 
     const toggle = () => setOpen(!open);
+
+    const getSuggestions = (e: ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        if (value.length > 0) {
+            const regex = new RegExp(`^${value}`, 'i');
+            const autocomplete = items.sort().filter((v: DropdownItem) => regex.test(v.label));
+            setSuggestions(autocomplete);
+        } else {
+            setSuggestions(items);
+        }
+    };
 
     function handleOnClick(item: DropdownItem) {
         onChange(item);
@@ -53,14 +74,18 @@ const Dropdown: React.FC<DropdownProps> = ({ items, multiSelect, title, reset, o
         <div ref={fragmentRef}>
             <Wrapper>
                 <Header tabIndex={0} role="button" onClick={toggle}>
-                    <Title>
-                        {selection.length > 0 ? selection.map(v => v.label).join(', ') : title}
-                    </Title>
+                    {searchable && !multiSelect ? (
+                        <input placeholder="Find chromosome..." onChange={getSuggestions} />
+                    ) : (
+                        <Title>
+                            {selection.length > 0 ? selection.map(v => v.label).join(', ') : title}
+                        </Title>
+                    )}
                     {open ? <BsChevronUp /> : <BsChevronDown />}
                 </Header>
                 {open && (
                     <List>
-                        {items.map(item => (
+                        {suggestions.map(item => (
                             <li key={item.id}>
                                 <button type="button" onClick={() => handleOnClick(item)}>
                                     <span>{item.label}</span>

--- a/react/src/components/Dropdown/Dropdown.tsx
+++ b/react/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
+import { useClickAway } from '../../hooks';
 import { DropdownItem } from '../../types';
 import { Header, List, Title, Wrapper } from './Dropdown.styles';
 
@@ -45,27 +46,32 @@ const Dropdown: React.FC<DropdownProps> = ({ items, multiSelect, title, reset, o
         }
     }, [reset]);
 
+    const fragmentRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+    useClickAway(fragmentRef, () => setOpen(false));
+
     return (
-        <Wrapper>
-            <Header tabIndex={0} role="button" onClick={toggle}>
-                <Title>
-                    {selection.length > 0 ? selection.map(v => v.label).join(', ') : title}
-                </Title>
-                {open ? <BsChevronUp /> : <BsChevronDown />}
-            </Header>
-            {open && (
-                <List>
-                    {items.map(item => (
-                        <li key={item.id}>
-                            <button type="button" onClick={() => handleOnClick(item)}>
-                                <span>{item.label}</span>
-                                <span>{isItemSelected(item) && 'Selected'}</span>
-                            </button>
-                        </li>
-                    ))}
-                </List>
-            )}
-        </Wrapper>
+        <div ref={fragmentRef}>
+            <Wrapper>
+                <Header tabIndex={0} role="button" onClick={toggle}>
+                    <Title>
+                        {selection.length > 0 ? selection.map(v => v.label).join(', ') : title}
+                    </Title>
+                    {open ? <BsChevronUp /> : <BsChevronDown />}
+                </Header>
+                {open && (
+                    <List>
+                        {items.map(item => (
+                            <li key={item.id}>
+                                <button type="button" onClick={() => handleOnClick(item)}>
+                                    <span>{item.label}</span>
+                                    <span>{isItemSelected(item) && 'Selected'}</span>
+                                </button>
+                            </li>
+                        ))}
+                    </List>
+                )}
+            </Wrapper>
+        </div>
     );
 };
 

--- a/react/src/components/Dropdown/Dropdown.tsx
+++ b/react/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 import { BsChevronDown, BsChevronUp } from 'react-icons/bs';
 import { useClickAway } from '../../hooks';
 import { DropdownItem } from '../../types';
-import { Header, List, Title, Wrapper } from './Dropdown.styles';
+import { Input, Header, List, Title, Wrapper } from './Dropdown.styles';
 
 interface DropdownProps {
     title: string;
@@ -11,6 +11,7 @@ interface DropdownProps {
     reset?: Boolean;
     multiSelect?: boolean;
     searchable?: boolean;
+    value?: string | number;
 }
 
 const Dropdown: React.FC<DropdownProps> = ({
@@ -19,17 +20,25 @@ const Dropdown: React.FC<DropdownProps> = ({
     title,
     reset,
     searchable,
+    value,
     onChange,
 }) => {
+    const [text, setText] = useState(value);
     const [open, setOpen] = useState<Boolean>(false);
     const [selection, setSelection] = useState<DropdownItem[]>([]);
     const [suggestions, setSuggestions] = useState<DropdownItem[]>(items);
-    console.log(suggestions);
 
     const toggle = () => setOpen(!open);
 
     const getSuggestions = (e: ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
+        setText(value);
+        setOpen(true);
+        onChange({
+            id: 1,
+            value: value,
+            label: value,
+        });
         if (value.length > 0) {
             const regex = new RegExp(`^${value}`, 'i');
             const autocomplete = items.sort().filter((v: DropdownItem) => regex.test(v.label));
@@ -67,6 +76,16 @@ const Dropdown: React.FC<DropdownProps> = ({
         }
     }, [reset]);
 
+    useEffect(() => {
+        if (searchable && selection.length > 0) {
+            setText(selection[0].value);
+        }
+    }, [selection]);
+
+    useEffect(() => {
+        setText(value);
+    }, [value]);
+
     const fragmentRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
     useClickAway(fragmentRef, () => setOpen(false));
 
@@ -75,7 +94,11 @@ const Dropdown: React.FC<DropdownProps> = ({
             <Wrapper>
                 <Header tabIndex={0} role="button" onClick={toggle}>
                     {searchable && !multiSelect ? (
-                        <input placeholder="Find chromosome..." onChange={getSuggestions} />
+                        <Input
+                            value={text}
+                            placeholder="Find chromosome..."
+                            onChange={getSuggestions}
+                        />
                     ) : (
                         <Title>
                             {selection.length > 0 ? selection.map(v => v.label).join(', ') : title}

--- a/react/src/components/Layout.tsx
+++ b/react/src/components/Layout.tsx
@@ -16,6 +16,12 @@ export const Column = styled(Flex)`
     margin-bottom: 0px;
 `;
 
+export const ButtonWrapper = styled(Flex)`
+    flex-direction: row;
+    align-items: flex-end;
+    margin: 0;
+`;
+
 export const Container = styled.div`
     margin: 0 auto;
     padding: 0 ${props => props.theme.space[6]};

--- a/react/src/components/Layout.tsx
+++ b/react/src/components/Layout.tsx
@@ -17,9 +17,8 @@ export const Column = styled(Flex)`
 `;
 
 export const ButtonWrapper = styled(Flex)`
-    flex-direction: row;
-    align-items: flex-end;
-    margin: 0;
+    display: inline-flex;
+    margin-top: 1.5rem;
 `;
 
 export const Container = styled.div`

--- a/react/src/components/Spinner.tsx
+++ b/react/src/components/Spinner.tsx
@@ -13,6 +13,8 @@ export const Loader = styled.div`
     border: ${props => props.theme.borders.thin} rgba(0, 0, 0, 0.1);
     border-top: ${props => props.theme.borders.thin} #767676;
     border-radius: 50%;
+    margin-inline-start: ${props => props.theme.space[3]};
+    margin-top: 35px;
     width: ${props => props.theme.space[5]};
     height: ${props => props.theme.space[5]};
     animation: ${spin} 0.6s linear infinite;

--- a/react/src/components/Table/Table.styles.tsx
+++ b/react/src/components/Table/Table.styles.tsx
@@ -40,6 +40,10 @@ export const Row = styled.tr`
         align-items: center;
     }
 
+    th > span > * {
+        margin: ${props => props.theme.space[3]};
+    }
+
     & > td {
         font-size: ${props => props.theme.fontSizes.s};
         padding: ${props => props.theme.space[3]};

--- a/react/src/components/Table/Table.styles.tsx
+++ b/react/src/components/Table/Table.styles.tsx
@@ -57,6 +57,8 @@ export const Row = styled.tr`
 export const Footer = styled.div`
     display: flex; 
     align-items: center;
+    justify-content: flex-end;
+    margin-right: ${props => props.theme.space[3]};
 
     * {
         padding: ${props => props.theme.space[2]};
@@ -66,6 +68,7 @@ export const Footer = styled.div`
 
     span {
         display: flex;
+        align-items: center; 
         margin-right: ${props => props.theme.space[4]}
     }
     

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -140,8 +140,8 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                     );
                                     return (
                                         <th key={key} {...restHeaderProps}>
-                                            {column.render('Header')}
                                             <span>
+                                                {column.render('Header')}
                                                 {column.isSorted ? (
                                                     column.isSortedDesc ? (
                                                         <BsFillCaretUpFill />

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -1,7 +1,7 @@
 import Button from './Button';
 import Dropdown from './Dropdown/Dropdown';
 import Input from './Input';
-import { ButtonWrapper, Body, Column, Container, Flex } from './Layout';
+import { Body, ButtonWrapper, Column, Container, Flex } from './Layout';
 import Navbar from './Navbar/Navbar';
 import Spinner from './Spinner';
 import Table from './Table/Table';

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -1,7 +1,7 @@
 import Button from './Button';
 import Dropdown from './Dropdown/Dropdown';
 import Input from './Input';
-import { Body, Column, Container, Flex } from './Layout';
+import { ButtonWrapper, Body, Column, Container, Flex } from './Layout';
 import Navbar from './Navbar/Navbar';
 import Spinner from './Spinner';
 import Table from './Table/Table';
@@ -9,6 +9,7 @@ import Typography from './Typography';
 
 export {
     Button,
+    ButtonWrapper,
     Body,
     Column,
     Container,

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+import useClickAway from './useClickAway';
 import useFormReducer from './useFormReducer';
 
-export { useFormReducer };
+export { useClickAway, useFormReducer };

--- a/react/src/hooks/useClickAway.tsx
+++ b/react/src/hooks/useClickAway.tsx
@@ -6,7 +6,7 @@ const useClickAway = <T extends HTMLElement>(
 ) => {
     return useEffect(() => {
         const listener = (e: Event) => {
-            if (!containerRef.current.contains(e.target as Node)) {
+            if (!containerRef.current?.contains(e.target as Node)) {
                 onAwayClick();
             }
         };

--- a/react/src/hooks/useClickAway.tsx
+++ b/react/src/hooks/useClickAway.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+const useClickAway = <T extends HTMLElement>(
+    containerRef: React.MutableRefObject<T>,
+    onAwayClick: () => void
+) => {
+    return useEffect(() => {
+        const listener = (e: Event) => {
+            if (!containerRef.current.contains(e.target as Node)) {
+                onAwayClick();
+            }
+        };
+        window.document.addEventListener('click', listener);
+        return () => window.document.removeEventListener('onclick', listener);
+    }, [containerRef, onAwayClick]);
+};
+
+export default useClickAway;

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useFetchVariantsQuery } from '../apollo/hooks';
 import {
     Body,
@@ -124,7 +124,6 @@ const VariantQueryPage: React.FC<{}> = () => {
     });
 
     const [fetchVariants, { data, loading }] = useFetchVariantsQuery();
-    const [reset, setReset] = useState<Boolean>(false);
 
     // Todo: Enable typings for only 'emsembl' | 'local'
     const toggleSource = (source: string) => {
@@ -145,13 +144,10 @@ const VariantQueryPage: React.FC<{}> = () => {
                         </Typography>
                         <Dropdown
                             title="Select Sources"
+                            value={queryOptionsForm.sources.value}
                             items={sources}
                             multiSelect
-                            onChange={item => {
-                                toggleSource(item.value);
-                                setReset(false);
-                            }}
-                            reset={reset}
+                            onChange={item => toggleSource(item.value)}
                         />
                         <ErrorIndicator error={queryOptionsForm.sources.error} />
                     </Column>
@@ -163,11 +159,7 @@ const VariantQueryPage: React.FC<{}> = () => {
                             value={queryOptionsForm.chromosome.value}
                             title="Select Chromosome"
                             items={chromosomes}
-                            onChange={e => {
-                                setReset(false);
-                                updateQueryOptionsForm('chromosome')(e.value);
-                            }}
-                            reset={reset}
+                            onChange={e => updateQueryOptionsForm('chromosome')(e.value)}
                             searchable
                         />
                         <ErrorIndicator error={queryOptionsForm.chromosome.error} />
@@ -204,15 +196,14 @@ const VariantQueryPage: React.FC<{}> = () => {
                         </Button>
                         <Button
                             onClick={() => {
-                                setReset(true);
                                 resetQueryOptionsForm();
                             }}
                             variant="primary"
                         >
                             Clear
                         </Button>
-                        {loading ? <Spinner /> : null}
                     </ButtonWrapper>
+                    {loading ? <Spinner /> : null}
                 </Flex>
             </div>
             {data ? <Table variantData={prepareData(data.getVariants)} /> : null}

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -3,6 +3,7 @@ import { useFetchVariantsQuery } from '../apollo/hooks';
 import {
     Body,
     Button,
+    ButtonWrapper,
     Column,
     Dropdown,
     Flex,
@@ -176,27 +177,27 @@ const VariantQueryPage: React.FC<{}> = () => {
                         />
                         <ErrorIndicator error={queryOptionsForm.end.error} />
                     </Column>
-                </Flex>
-                <Flex>
-                    <Button
-                        disabled={
-                            loading || !formIsValid(queryOptionsForm, queryOptionsFormValidator)
-                        }
-                        onClick={() => fetchVariants({ variables: getArgs() })}
-                        variant="primary"
-                    >
-                        Fetch
-                    </Button>
-                    <Button
-                        onClick={() => {
-                            setReset(true);
-                            resetQueryOptionsForm();
-                        }}
-                        variant="primary"
-                    >
-                        Clear
-                    </Button>
-                    <Column>{loading ? <Spinner /> : null}</Column>
+                    <ButtonWrapper>
+                        <Button
+                            disabled={
+                                loading || !formIsValid(queryOptionsForm, queryOptionsFormValidator)
+                            }
+                            onClick={() => fetchVariants({ variables: getArgs() })}
+                            variant="primary"
+                        >
+                            Fetch
+                        </Button>
+                        <Button
+                            onClick={() => {
+                                setReset(true);
+                                resetQueryOptionsForm();
+                            }}
+                            variant="primary"
+                        >
+                            Clear
+                        </Button>
+                        {loading ? <Spinner /> : null}
+                    </ButtonWrapper>
                 </Flex>
             </div>
             {data ? <Table variantData={prepareData(data.getVariants)} /> : null}

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -16,6 +16,33 @@ import { useFormReducer } from '../hooks';
 import { formIsValid, FormState } from '../hooks/useFormReducer';
 import { DropdownItem, VariantQueryResponse, VariantQueryResponseSchemaTableRow } from '../types';
 
+const sources: DropdownItem[] = [
+    {
+        id: 1,
+        value: 'local',
+        label: 'Local',
+    },
+    {
+        id: 2,
+        value: 'ensembl',
+        label: 'Ensembl',
+    },
+];
+
+const chromosomes: DropdownItem[] = Array.from(Array(22))
+    .map((v, i) => ({
+        id: i,
+        value: (i + 1).toString(),
+        label: (i + 1).toString(),
+    }))
+    .concat(
+        ['X', 'Y'].map((v, i) => ({
+            id: 22 + i,
+            value: v,
+            label: v,
+        }))
+    );
+
 const queryOptionsFormValidator = {
     sources: {
         required: true,
@@ -23,7 +50,7 @@ const queryOptionsFormValidator = {
             {
                 valid: (state: FormState<QueryOptionsFormState>) =>
                     !!state.sources.value.filter(s => ['local', 'ensembl'].includes(s)).length,
-                error: 'Invalid source!',
+                error: 'Please specify a source.',
             },
         ],
     },
@@ -44,6 +71,16 @@ const queryOptionsFormValidator = {
                 valid: (state: FormState<QueryOptionsFormState>) =>
                     +state.start.value < +state.end.value,
                 error: 'End must be greater than start!',
+            },
+        ],
+    },
+    chromosome: {
+        required: true,
+        rules: [
+            {
+                valid: (state: FormState<QueryOptionsFormState>) =>
+                    !!chromosomes.map(c => c.value).includes(state.chromosome.value),
+                error: 'Chromosome is invalid.',
             },
         ],
     },
@@ -98,33 +135,6 @@ const VariantQueryPage: React.FC<{}> = () => {
             : update(queryOptionsForm.sources.value.concat(source));
     };
 
-    const sources: DropdownItem[] = [
-        {
-            id: 1,
-            value: 'local',
-            label: 'Local',
-        },
-        {
-            id: 2,
-            value: 'ensembl',
-            label: 'Ensembl',
-        },
-    ];
-
-    const chromosomes: DropdownItem[] = Array.from(Array(22))
-        .map((v, i) => ({
-            id: i,
-            value: (i + 1).toString(),
-            label: (i + 1).toString(),
-        }))
-        .concat(
-            ['X', 'Y'].map((v, i) => ({
-                id: 22 + i,
-                value: v,
-                label: v,
-            }))
-        );
-
     return (
         <Body>
             <div>
@@ -150,6 +160,7 @@ const VariantQueryPage: React.FC<{}> = () => {
                             Chromosomes
                         </Typography>
                         <Dropdown
+                            value={queryOptionsForm.chromosome.value}
                             title="Select Chromosome"
                             items={chromosomes}
                             onChange={e => {
@@ -159,6 +170,7 @@ const VariantQueryPage: React.FC<{}> = () => {
                             reset={reset}
                             searchable
                         />
+                        <ErrorIndicator error={queryOptionsForm.chromosome.error} />
                     </Column>
                     <Column>
                         <Typography variant="subtitle" bold>

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -75,6 +75,8 @@ const VariantQueryPage: React.FC<{}> = () => {
             queryOptionsFormValidator
         );
 
+    console.log(queryOptionsForm);
+
     const getArgs = () => ({
         input: {
             chromosome: queryOptionsForm.chromosome.value,
@@ -155,6 +157,7 @@ const VariantQueryPage: React.FC<{}> = () => {
                                 updateQueryOptionsForm('chromosome')(e.value);
                             }}
                             reset={reset}
+                            searchable
                         />
                     </Column>
                     <Column>


### PR DESCRIPTION
- Added `searchable` prop to `Dropdown` component. Note that this currently works only with single-select autocomplete and not yet with multi-select autocomplete. I'm planning to add this functionality sometime down the road.
- Made dropdown fixed width.
- Added click away functionality for dropdown.
- Moved filter column to be next to Header (as opposed to below like before) in `Table`.
- Moved button to be on the same row as search filters.