### PR TITLE
Docker: use init option to cleanup zombie node processes 

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   ssmp-server:
     image: ghcr.io/ccmbioinfo/ssmp:dev
+    init: true
     environment:
       TEST_NODE_URL: ${TEST_NODE_URL}
       KEYCLOAK_AUTH_URL: ${KEYCLOAK_AUTH_URL}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       context: server
       target: BUILD_IMAGE
     image: ghcr.io/ccmbioinfo/ssmp:dev
+    init: true
     environment:
       KEYCLOAK_AUTH_URL: ${KEYCLOAK_AUTH_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}

--- a/server/src/resolvers/getVariantsResolver/utils/fetchCaddAnnotations.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/fetchCaddAnnotations.ts
@@ -4,7 +4,6 @@ import { promisify } from 'util';
 import resolveAssembly from './resolveAssembly';
 import { v4 as uuidv4 } from 'uuid';
 import { CADDAnnotationQueryResponse, CaddAnnotation } from '../../../types';
-import logger from '../../../logger';
 
 const ANNOTATION_URL_38 =
   'https://krishna.gs.washington.edu/download/CADD/v1.6/GRCh38/whole_genome_SNVs_inclAnno.tsv.gz';
@@ -63,15 +62,7 @@ const _getAnnotations = async (position: string, assemblyId: string) => {
   const query = await _buildQuery(position, assemblyId);
   const execPromise = promisify(exec);
 
-  let response;
-  try {
-    response = execPromise(query, { maxBuffer: 10e7 }); // 100mb
-  } catch (err) {
-    logger.error(err);
-    throw err;
-  }
-
-  return response;
+  return execPromise(query, { maxBuffer: 10e7 }); // 100mb
 };
 
 const _formatAnnotations = (annotations: string) => {


### PR DESCRIPTION
When node experiences an error while executing a child process, the child process may persist as a zombie. The `init` option takes care of this (docs [here](https://docs.docker.com/engine/reference/run/#specify-an-init-process), discussion [here](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/)) 