### PR TITLE
React: fix assembly labels and gene search 

### DIFF
--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -5,39 +5,6 @@ import { AssemblyId } from '../types';
 import ComboBox from './ComboBox';
 import { SelectableListItem } from './SelectableList';
 
-interface AutocompleteResults {
-    autocompleteResults: {
-        hits: {
-            symbol: string;
-            ensembl: {
-                gene: string;
-            };
-            genomic_pos: {
-                chr: string;
-                end: number;
-                start: number;
-            };
-            genomic_pos_hg19: {
-                chr: string;
-                end: number;
-                start: number;
-            };
-        }[];
-    };
-}
-interface SelectionValue {
-    ensemblId: string;
-    name: string;
-    position: string;
-}
-
-interface GeneSearchProps {
-    assembly: AssemblyId;
-    geneName: string;
-    onSelect: (gene: SelectionValue) => void;
-    onChange: (geneName: string) => void;
-}
-
 interface HitPosition {
     chr: string;
     start: number;
@@ -47,6 +14,30 @@ interface HitPosition {
 interface HitPositions {
     genomic_pos: HitPosition;
     genomic_pos_hg19: HitPosition;
+}
+interface AutocompleteResults {
+    autocompleteResults: {
+        hits?: {
+            symbol: string;
+            ensembl?: {
+                gene: string;
+            };
+            genomic_pos: HitPosition;
+            genomic_pos_hg19: HitPosition;
+        }[];
+    };
+}
+interface SelectionValue {
+    ensemblId?: string;
+    name: string;
+    position: string;
+}
+
+interface GeneSearchProps {
+    assembly: AssemblyId;
+    geneName: string;
+    onSelect: (gene: SelectionValue) => void;
+    onChange: (geneName: string) => void;
 }
 
 const getPosition = (assembly: AssemblyId, position: HitPositions) => {

--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -61,8 +61,6 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
     const [fetchAutocompleteResults, { data: autocompleteResults, loading: autocompleteLoading }] =
         useFetchAutocompleteQuery();
 
-    console.log(options, autocompleteResults);
-
     const debouncedAutocompleteFetch = useAsyncDebounce(fetchAutocompleteResults, 500);
 
     const formatAutocompleteOptions = useCallback(

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -77,7 +77,7 @@ const queryOptionsFormValidator: Validator<QueryOptionsFormState> = {
 };
 
 interface QueryOptionsFormState {
-    assemblyId: AssemblyId;
+    assemblyId: string;
     ensemblId: string;
     gene: string;
     maxFrequency: string;
@@ -115,7 +115,7 @@ const VariantQueryPage: React.FC<{}> = () => {
     const getArgs = () => ({
         input: {
             variant: {
-                assemblyId: queryOptionsForm.assemblyId.value,
+                assemblyId: resolveAssembly(queryOptionsForm.assemblyId.value),
                 maxFrequency: +queryOptionsForm.maxFrequency.value,
             },
             gene: {
@@ -167,7 +167,7 @@ const VariantQueryPage: React.FC<{}> = () => {
                             Gene Name
                         </Typography>
                         <GeneSearch
-                            assembly={queryOptionsForm.assemblyId.value}
+                            assembly={resolveAssembly(queryOptionsForm.assemblyId.value)}
                             geneName={queryOptionsForm.gene.value}
                             onChange={geneName =>
                                 updateQueryOptionsForm({ gene: geneName, ensemblId: '' })
@@ -227,7 +227,7 @@ const VariantQueryPage: React.FC<{}> = () => {
                             }
                             options={['GRCh37', 'GRCh38'].map((a, id) => ({
                                 id,
-                                value: resolveAssembly(a),
+                                value: a,
                                 label: a,
                             }))}
                             placeholder="Select"

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -112,20 +112,21 @@ const VariantQueryPage: React.FC<{}> = () => {
             queryOptionsFormValidator
         );
 
-    const getArgs = () => ({
-        input: {
-            variant: {
-                assemblyId: resolveAssembly(queryOptionsForm.assemblyId.value),
-                maxFrequency: +queryOptionsForm.maxFrequency.value,
+    const getArgs = () =>
+        ({
+            input: {
+                variant: {
+                    assemblyId: resolveAssembly(queryOptionsForm.assemblyId.value),
+                    maxFrequency: +queryOptionsForm.maxFrequency.value,
+                },
+                gene: {
+                    ensemblId: queryOptionsForm.ensemblId.value,
+                    geneName: queryOptionsForm.gene.value,
+                    position: queryOptionsForm.position.value,
+                },
+                sources: queryOptionsForm.sources.value,
             },
-            gene: {
-                ensemblId: queryOptionsForm.ensemblId.value,
-                geneName: queryOptionsForm.gene.value,
-                position: queryOptionsForm.position.value,
-            },
-            sources: queryOptionsForm.sources.value,
-        },
-    });
+        } as const);
 
     const [fetchVariants, { data, loading }] = useFetchVariantsQuery();
 

--- a/react/src/utils/resolveAssembly.ts
+++ b/react/src/utils/resolveAssembly.ts
@@ -1,11 +1,6 @@
-const resolveAssembly = (assembly: string) => {
-    if (assembly.includes('37') || assembly.toLowerCase().includes('hg19')) {
-        return '37';
-    } else if (assembly.includes('38')) {
-        return '38';
-    } else {
-        return '';
-    }
-};
+import { AssemblyId } from '../types';
+
+const resolveAssembly: (assembly: string) => AssemblyId = assembly =>
+    assembly.includes('38') ? '38' : '37';
 
 export default resolveAssembly;

--- a/react/src/utils/resolveAssembly.ts
+++ b/react/src/utils/resolveAssembly.ts
@@ -1,6 +1,3 @@
-import { AssemblyId } from '../types';
-
-const resolveAssembly = (assembly: string) =>
-    assembly.includes('38') ? '38' : '37' as AssemblyId;
+const resolveAssembly = (assembly: string) => (assembly.includes('38') ? '38' : '37');
 
 export default resolveAssembly;

--- a/react/src/utils/resolveAssembly.ts
+++ b/react/src/utils/resolveAssembly.ts
@@ -1,6 +1,6 @@
 import { AssemblyId } from '../types';
 
-const resolveAssembly = (assembly: AssemblyId) =>
-    assembly.includes('38') ? '38' : ('37' as const);
+const resolveAssembly = (assembly: string) =>
+    assembly.includes('38') ? '38' : ('37' as AssemblyId);
 
 export default resolveAssembly;

--- a/react/src/utils/resolveAssembly.ts
+++ b/react/src/utils/resolveAssembly.ts
@@ -1,6 +1,6 @@
 import { AssemblyId } from '../types';
 
 const resolveAssembly = (assembly: string) =>
-    assembly.includes('38') ? '38' : ('37' as AssemblyId);
+    assembly.includes('38') ? '38' : '37' as AssemblyId;
 
 export default resolveAssembly;

--- a/react/src/utils/resolveAssembly.ts
+++ b/react/src/utils/resolveAssembly.ts
@@ -1,6 +1,6 @@
 import { AssemblyId } from '../types';
 
-const resolveAssembly: (assembly: string) => AssemblyId = assembly =>
-    assembly.includes('38') ? '38' : '37';
+const resolveAssembly = (assembly: AssemblyId) =>
+    assembly.includes('38') ? '38' : ('37' as const);
 
 export default resolveAssembly;

--- a/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
@@ -1,6 +1,6 @@
 import { AssemblyId } from '../../../types';
 
-const resolveAssembly: (assembly: string) => AssemblyId = assembly =>
-  assembly.includes('38') ? '38' : '37';
+const resolveAssembly = (assembly: AssemblyId) =>
+  assembly.includes('38') ? '38' : ('37' as const);
 
 export default resolveAssembly;

--- a/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
@@ -1,6 +1,3 @@
-import { AssemblyId } from '../../../types';
-
-const resolveAssembly = (assembly: string) =>
-  assembly.includes('38') ? '38' : '37' as AssemblyId;
+const resolveAssembly = (assembly: string) => (assembly.includes('38') ? '38' : '37');
 
 export default resolveAssembly;

--- a/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
@@ -1,11 +1,6 @@
-const resolveAssembly = (assembly: string) => {
-  if (assembly.includes('37') || assembly.toLowerCase().includes('hg19')) {
-    return '37';
-  } else if (assembly.includes('38')) {
-    return '38';
-  } else {
-    return '';
-  }
-};
+import { AssemblyId } from '../../../types';
+
+const resolveAssembly: (assembly: string) => AssemblyId = assembly =>
+  assembly.includes('38') ? '38' : '37';
 
 export default resolveAssembly;

--- a/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
@@ -1,6 +1,6 @@
 import { AssemblyId } from '../../../types';
 
-const resolveAssembly = (assembly: AssemblyId) =>
-  assembly.includes('38') ? '38' : ('37' as const);
+const resolveAssembly = (assembly: string) =>
+  assembly.includes('38') ? '38' : ('37' as AssemblyId);
 
 export default resolveAssembly;

--- a/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/resolveAssembly.ts
@@ -1,6 +1,6 @@
 import { AssemblyId } from '../../../types';
 
 const resolveAssembly = (assembly: string) =>
-  assembly.includes('38') ? '38' : ('37' as AssemblyId);
+  assembly.includes('38') ? '38' : '37' as AssemblyId;
 
 export default resolveAssembly;


### PR DESCRIPTION
- Assembly ID selection now reflects the full form of the reference genome (GChr38/37 instead of 38, 37).
- Before, if the user types in the same gene name as before, no autocomplete results would be shown in the dropdown. Adding `geneName` as a dependency to the `useEffect` hook responsible for setting options in the dropdown fixes this issue.