### PR TITLE
Documentation: Update Docker development process 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A one-sided variant matching portal to support rare disease research
 
-The One-Sided Matching Portal (OSMP) enables researchers to query patient variant and phenotype data from many different sources simultaneously. Acting as a hub connecting disparate data sources, the portal processes user queries, routes them to their respective endpoints with appropriate authorization, and amalgamates their results into a single, easily-searchable collection displayed in a user-friendly interface. By allowing researchers to search patient data from several research institutions with a single query, the OSMP can significantly speed up the process of rare disease “matching” across institutions and datasets. 
+The One-Sided Matching Portal (OSMP) enables researchers to query patient variant and phenotype data from many different sources simultaneously. Acting as a hub connecting disparate data sources, the portal processes user queries, routes them to their respective endpoints with appropriate authorization, and amalgamates their results into a single, easily-searchable collection displayed in a user-friendly interface. By allowing researchers to search patient data from several research institutions with a single query, the OSMP can significantly speed up the process of rare disease “matching” across institutions and datasets.
 
 ## Front End
 
@@ -50,18 +50,34 @@ The back end is a node.js server built with [express](https://expressjs.com/), [
   - ```bash
     docker-compose run --rm --entrypoint='yarn test' ssmp-server
     ```
-    
-### Connecting to Phenotips 
+
+### Connecting to Phenotips
 
 The Phenotips variant matching endpoint specified [here](https://github.com/ccmbioinfo/report-scripts/blob/master/phenotips-api.md#matching-endpoint) can only be reached directly from our staging virtual machine ubuntu@ssmp-dev in the [CHEO-RI tenancy](https://github.com/ccmbioinfo/cheo-ri-infrastructure).
 
-In development, for the Express server to successfully make a call to the endpoint, we need to use SSH's local forwarding protocol to forward a port from your local machine to the staging server machine. The SSH client listens to any requests or connections on a configured port, and when it receives a connection, it tunnels the connection to the SSH server. 
+In development, for the Express server to successfully make a call to the endpoint, we need to use SSH's local forwarding protocol to forward a port from your local machine to the staging server machine. The SSH client listens to any requests or connections on a configured port, and when it receives a connection, it tunnels the connection to the SSH server.
 
-If you are using CCM's VMs, you can set up local forwarding as follows: 
-  - To login into your VM: ```eval $(ssh-agent -s) && ssh-add``` and ```ssh -A <username>@dev-<username>.ccm.sickkids.ca```. Make sure that you already have a VM allocated to you. 
-  - To forward your local port to ubuntu@ssmp-dev: ```ssh -ANL 0.0.0.0:8443:dev.phenotips.genomics4rd.ca:443 ubuntu@ssmp.ccmdev.ca```. For now, this command would need to be run alongside `docker-compose up` when you want to bring up the app.
-  - Set ```G4RD_URL``` in your local ```.env``` to ```https://dev-<username>.ccm.sickkids.ca:8443```.
-Now, any request sent to your ```G4RD_URL``` would be tunneled to ```dev.phenotips.genomics4rd.ca:443``` on the staging VM. 
+If you are using CCM's VMs, you can set up local forwarding as follows:
+
+- To login into your VM: `eval $(ssh-agent -s) && ssh-add` and `ssh -A <username>@dev-<username>.ccm.sickkids.ca`. Make sure that you already have a VM allocated to you.
+- To forward your local port to ubuntu@ssmp-dev: `ssh -ANL 0.0.0.0:8443:dev.phenotips.genomics4rd.ca:443 ubuntu@ssmp.ccmdev.ca`. For now, this command would need to be run alongside `docker-compose up` when you want to bring up the app.
+- Set `G4RD_URL` in your local `.env` to `https://dev-<username>.ccm.sickkids.ca:8443`.
+  Now, any request sent to your `G4RD_URL` would be tunneled to `dev.phenotips.genomics4rd.ca:443` on the staging VM.
+
+### Building the remote test server
+
+Apart from Phenotips, another data source for the SSMP development instance is a Node/Express server that queries a MySQL database that has been populated wtih variants from the STAGER application database.
+
+- make sure the `.env` file exists (see above)
+- if this is your first time bringing up the app, install dependencies:
+  - ```bash
+    docker-compose run --rm --entrypoint='yarn install' test-node-1
+    ```
+- bring up the server using [docker-compose](https://docs.docker.com/compose/):
+
+  - ```bash
+    docker-compose up test-node-1
+    ```
 
 ## Keycloak
 
@@ -80,11 +96,11 @@ The keycloak admin portal can be accessed in the browser by navigating to localh
 Annotations can be imported into mongo using the following command. Note that that the headers should not be included in the csv and the order of the fields passed to the `fields` argument should match the order of the fields in the csv.
 
 ```bash
-mongoimport --db=annotations --collection=annotations --type=csv \
+mongoimport --collection=annotations --type=csv \
    --columnsHaveTypes \
    --fields="pos.int32(),ref.string(),alt.string(),chrom.string(),nhomalt.int32(),an.int32(),af.double(),assembly.string()" \
    --file=<filename>.csv \
-   -u <username> --password=<pass> --authenticationDatabase=admin
+   --uri=mongodb://<env.MONGO_INITDB_ROOT_USERNAME>:<env.MONGO_INITDB_ROOT_PASSWORD>@mango/<env.MONGO_INITDB_DATABASE>?autoSource=admin
 ```
 
 Then make sure to create the following indexes:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Apart from Phenotips, another data source for the SSMP development instance is a
     docker-compose up test-node-1
     ```
 
+- to populate MySQL database with variants from STAGER, download this [script](https://sickkidsca.sharepoint.com/:u:/r/sites/thecenterforcomputationalmedicineworkspace/Shared%20Documents/SSMP/data/stager-local-20210716.sql?csf=1&web=1&e=fVzHIB) and run the script using one of these two options:
+  - MySQLWorkbench
+  - ```bash
+    docker exec -i <stager-mysql-container-name> mysql -u <env.STAGER_DB_USER> --password="<env.STAGER_DB_PASSWORD>" <env.STAGER_DB> < <filepath>.sql
+    ```
+    where the `.sql` script is on the host machine.
+
 ## Keycloak
 
 The app uses [keycloak](https://www.keycloak.org/) as an identity provider and identity broker. Essentially, keycloak stores all user information and the app is a keycloak client. The implementation is currently in its earliest phases and documentation will be updated as the project evolves.
@@ -100,7 +107,7 @@ mongoimport --collection=annotations --type=csv \
    --columnsHaveTypes \
    --fields="pos.int32(),ref.string(),alt.string(),chrom.string(),nhomalt.int32(),an.int32(),af.double(),assembly.string()" \
    --file=<filename>.csv \
-   --uri=mongodb://<env.MONGO_INITDB_ROOT_USERNAME>:<env.MONGO_INITDB_ROOT_PASSWORD>@mango/<env.MONGO_INITDB_DATABASE>?autoSource=admin
+   --uri=mongodb://<env.MONGO_INITDB_ROOT_USERNAME>:<env.MONGO_INITDB_ROOT_PASSWORD>@mongo/<env.MONGO_INITDB_DATABASE>?authSource=admin
 ```
 
 Then make sure to create the following indexes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -100,6 +100,8 @@ services:
       MYSQL_USER: "${STAGER_DB_USER}"
       MYSQL_PASSWORD: "${STAGER_DB_PASSWORD}"
       MYSQL_ROOT_PASSWORD: "${STAGER_DB_ROOT_PASSWORD}"
+    ports: 
+      - ${STAGER_DB_PORT}:3306 
     volumes:
       - ${STAGER_DATA_VOLUME}:/var/lib/mysql
     networks:


### PR DESCRIPTION
- Expose `stager-mysql` container's port 3306 in `docker-compose.yaml`
- Add workflow for building and running the service `test-node-1`
- Change `mongoimport` statement since `--url` needs to be specified in a Docker containerized development environment. 