### PR TITLE
React: Standardize the display for Zygosity column

### DIFF
--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -193,7 +193,12 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         width: 70,
                     },
                     {
-                        accessor: 'zygosity',
+                        accessor: state =>
+                            state.zygosity?.toLowerCase().includes('het')
+                                ? 'Heterozygous'
+                                : state.zygosity?.toLowerCase().includes('hom')
+                                ? 'Homozygous'
+                                : state.zygosity,
                         filter: 'multiSelect',
                         id: 'zygosity',
                         Header: 'Zygosity',


### PR DESCRIPTION
If the `zygosity` field contains "het" or "hom" in lower case or upper case, display it as "Heterozygous" and "Homozygous" on the table, respectively. 
For other data that doesn't contain "het" or "hom", leave it as is. 