### PR TITLE
React: Collapse duplicate variant rows into one if Case Details section is collapsed. 

### DIFF
--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -91,12 +91,13 @@ const prepareData = (queryResult: VariantQueryDataResult[]): [ResultTableColumns
 
     sortedQueryResult.forEach(d => {
         const { ref, alt, start, end } = d.variant;
+
         if (JSON.stringify(currVariant) !== JSON.stringify({ ref, alt, start, end })) {
+            currVariant = { ref, alt, start, end };
             currUniqueId += 1;
             uniqueVariantIndices.push(currRowId);
-            currVariant = { ref, alt, start, end };
         }
-        const id = currUniqueId;
+
         if (d.variant.callsets.length) {
             result.push.apply(
                 result,
@@ -108,13 +109,13 @@ const prepareData = (queryResult: VariantQueryDataResult[]): [ResultTableColumns
                                 ...cs.info,
                                 ...flattenBaseResults(d),
                             },
-                            id
+                            currUniqueId
                         )
                     )
             );
             currRowId += d.variant.callsets.length;
         } else {
-            result.push(addAdditionalFieldsAndFormatNulls(flattenBaseResults(d), id));
+            result.push(addAdditionalFieldsAndFormatNulls(flattenBaseResults(d), currUniqueId));
             currRowId += 1;
         }
     });

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -80,15 +80,16 @@ const resolveSex = (sexPhenotype: string) => {
 // 2, Flatten data and compute values as needed (note that column display formatting function should not alter values for ease of export). Assign uniqueId to each row.
 const prepareData = (queryResult: VariantQueryDataResult[]): [ResultTableColumns[], number[]] => {
     const sortedQueryResult = sortQueryResult(queryResult);
-    var result: Array<ResultTableColumns> = [];
-    var uniqueVariantIndices: Array<number> = []; // contains indices of first encountered rows that represent unique variants.
-    const n = sortedQueryResult.length;
+
+    const result: Array<ResultTableColumns> = [];
+
+    const uniqueVariantIndices: Array<number> = []; // contains indices of first encountered rows that represent unique variants.
+
     var currVariant = {} as Variant;
     var currUniqueId = 0;
     var currRowId = 0;
 
-    for (let i = 0; i < n; i++) {
-        const d = sortedQueryResult[i];
+    sortedQueryResult.forEach(d => {
         const { ref, alt, start, end } = d.variant;
         if (JSON.stringify(currVariant) !== JSON.stringify({ ref, alt, start, end })) {
             currUniqueId += 1;
@@ -97,7 +98,8 @@ const prepareData = (queryResult: VariantQueryDataResult[]): [ResultTableColumns
         }
         const id = currUniqueId;
         if (d.variant.callsets.length) {
-            result = result.concat(
+            result.push.apply(
+                result,
                 d.variant.callsets
                     .filter(cs => cs.individualId === d.individual.individualId)
                     .map(cs =>
@@ -112,10 +114,11 @@ const prepareData = (queryResult: VariantQueryDataResult[]): [ResultTableColumns
             );
             currRowId += d.variant.callsets.length;
         } else {
-            result = result.concat(addAdditionalFieldsAndFormatNulls(flattenBaseResults(d), id));
+            result.push(addAdditionalFieldsAndFormatNulls(flattenBaseResults(d), id));
             currRowId += 1;
         }
-    }
+    });
+
     return [result, uniqueVariantIndices];
 };
 
@@ -504,7 +507,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                     individuals
                 </Typography>
                 {rows.length !== tableData.length && (
-                    <SummaryText>{rows.length} variants matching your filters</SummaryText>
+                    <SummaryText>{rows.length} individuals matching your filters</SummaryText>
                 )}
             </Column>
 

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -499,7 +499,10 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
 
             <Column>
                 <br />
-                <Typography variant="h3">{tableData.length} total variants found</Typography>
+                <Typography variant="h3">
+                    {uniqueVariantIndices.length} unique variants found in {tableData.length}{' '}
+                    individuals
+                </Typography>
                 {rows.length !== tableData.length && (
                     <SummaryText>{rows.length} variants matching your filters</SummaryText>
                 )}

--- a/react/src/utils/index.ts
+++ b/react/src/utils/index.ts
@@ -7,8 +7,10 @@ import {
     addAdditionalFieldsAndFormatNulls,
     calculateColumnWidth,
     flattenBaseResults,
+    isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
+    sortQueryResult,
 } from './tableHelpers';
 
 export {
@@ -19,7 +21,9 @@ export {
     flattenBaseResults,
     formatErrorMessage,
     getKeys,
+    isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
     resolveAssembly,
+    sortQueryResult,
 };

--- a/react/src/utils/tableHelpers.ts
+++ b/react/src/utils/tableHelpers.ts
@@ -22,6 +22,7 @@ export interface ResultTableColumns extends FlattenedQueryResponse {
     aaChange: string;
     emptyCaseDetails: string;
     emptyVariationDetails: string;
+    unique_id: number;
 }
 
 export const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQueryResponse => {
@@ -45,7 +46,8 @@ export const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQue
 };
 
 export const addAdditionalFieldsAndFormatNulls = (
-    results: FlattenedQueryResponse
+    results: FlattenedQueryResponse,
+    currId: number
 ): ResultTableColumns => {
     const reformatted = Object.fromEntries(
         Object.entries(results).map(([k, v]) => [k, v === 'NA' ? '' : v])
@@ -54,6 +56,7 @@ export const addAdditionalFieldsAndFormatNulls = (
         ...reformatted,
         emptyCaseDetails: '',
         emptyVariationDetails: '',
+        unique_id: currId,
         aaChange: reformatted.aaPos?.trim()
             ? `p.${reformatted.aaRef}${reformatted.aaPos}${reformatted.aaAlt}`
             : '',

--- a/react/src/utils/tableHelpers.ts
+++ b/react/src/utils/tableHelpers.ts
@@ -22,7 +22,7 @@ export interface ResultTableColumns extends FlattenedQueryResponse {
     aaChange: string;
     emptyCaseDetails: string;
     emptyVariationDetails: string;
-    unique_id: number;
+    uniqueId: number;
 }
 
 export const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQueryResponse => {
@@ -47,7 +47,7 @@ export const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQue
 
 export const addAdditionalFieldsAndFormatNulls = (
     results: FlattenedQueryResponse,
-    currId: number
+    uniqueId: number
 ): ResultTableColumns => {
     const reformatted = Object.fromEntries(
         Object.entries(results).map(([k, v]) => [k, v === 'NA' ? '' : v])
@@ -56,7 +56,7 @@ export const addAdditionalFieldsAndFormatNulls = (
         ...reformatted,
         emptyCaseDetails: '',
         emptyVariationDetails: '',
-        unique_id: currId,
+        uniqueId,
         aaChange: reformatted.aaPos?.trim()
             ? `p.${reformatted.aaRef}${reformatted.aaPos}${reformatted.aaAlt}`
             : '',
@@ -91,4 +91,20 @@ export const isHeaderExpanded = (column: HeaderGroup<ResultTableColumns>) => {
         return !intersection.length;
     }
     return false;
+};
+
+export const isCaseDetailsCollapsed = (headers: HeaderGroup<ResultTableColumns>[]) => {
+    const caseDetailsCol = headers.find(header => header.Header === 'Case Details');
+    return caseDetailsCol && !isHeaderExpanded(caseDetailsCol);
+};
+
+export const sortQueryResult = (queryResult: VariantQueryDataResult[]) => {
+    const sortedQueryResult = [...queryResult].sort(
+        (a, b) =>
+            a.variant.ref.localeCompare(b.variant.ref) ||
+            a.variant.alt.localeCompare(b.variant.alt) ||
+            a.variant.start - b.variant.start ||
+            a.variant.end - b.variant.end
+    );
+    return sortedQueryResult;
 };


### PR DESCRIPTION
-  Added a hidden column `unique_id`. Assign `unique_id` to the rows in increasing order according to the order of `chromosome`, `ref`, `alt`, `start`, `end`. The initial/default sorting scheme for the React Table is by ascending order of `unique_id`. 
- Implemented the duplicate variants collapsing feature when the Case Details section is collapsed. Note that the function `prepareData` returns an array of row indices for those rows that will be displayed when the Case Details section is collapsed. Thus, in the rendering, we only need to check if the current row index is in this array returned from function`prepareData`. 

Comments:

-  The if-else conditions in function`prepareData` are not shortened to retain readability, but if needed, the formal expression can be reduced. 
- @hannahle Your recent implementation of result display (ie: "n total variants found") would need to be changed to avoid confusion. 
- Users can hold the "shift" key to sort multiple columns at the same time. I suggest that we add a note on the UI to inform the user about this feature. @hannahle Any thoughts? 
- If other column(s) are sorted, `unique_id` column will not be sorted anymore. However, I think the current UI display when sorting different columns produces the original behavior we want. 