### PR TITLE
React: Add zygosity count columns, alternate rows' background colour 

### DIFF
--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -320,14 +320,14 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                     {
                         accessor: 'homozygousCount',
                         id: 'homozygousCount',
-                        Header: 'homozygous count',
-                        width: 150,
+                        Header: 'Homozygous Count',
+                        width: getColumnWidth(tableData, 'homozygousCount', 'Homozygous Count'),
                     },
                     {
                         accessor: 'heterozygousCount',
                         id: 'heterozygousCount',
-                        Header: 'heterozygous count',
-                        width: 150,
+                        Header: 'Heterozygous Count',
+                        width: getColumnWidth(tableData, 'heterozygousCount', 'Heterozygous Count'),
                     },
                     { accessor: 'cdna', id: 'cdna', Header: 'cdna', width: 105 },
                     {

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -422,6 +422,17 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
     const toggleGroupVisibility = (g: HeaderGroup<ResultTableColumns>) =>
         g.columns?.map(c => c.type !== 'fixed' && toggleHideColumn(c.id, c.isVisible));
 
+    var currColour = 'white';
+
+    const getRowColour = (uniqueId: number, previousRowUniqueId: number) => {
+        if (currColour === 'white' && uniqueId !== previousRowUniqueId) {
+            currColour = 'whitesmoke';
+        } else if (uniqueId !== previousRowUniqueId) {
+            currColour = 'white';
+        }
+        return [{ style: { background: currColour } }];
+    };
+
     return (
         <>
             <TableFilters justifyContent="space-between">
@@ -597,9 +608,17 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
 
                         <tbody {...getTableBodyProps()}>
                             {page.length > 0 ? (
-                                page.map(row => {
+                                page.map((row, i) => {
                                     prepareRow(row);
-                                    const { key, ...restRowProps } = row.getRowProps();
+                                    // Alternate row's background colour.
+                                    const { key, ...restRowProps } = row.getRowProps(
+                                        i !== 0
+                                            ? getRowColour(
+                                                  row.values['uniqueId'],
+                                                  page[i - 1].values['uniqueId']
+                                              )
+                                            : [{ style: { background: 'white' } }]
+                                    );
                                     // Display only one row per variant if Case Details Section is collapsed.
                                     if (
                                         isCaseDetailsCollapsed(headerGroups[0].headers) &&

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -32,6 +32,8 @@ import {
     isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
+    isHeterozygous,
+    isHomozygous,
     prepareData,
 } from '../../utils';
 import { Button, Flex, InlineFlex, Tooltip, Typography } from '../index';
@@ -186,9 +188,9 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                     },
                     {
                         accessor: state =>
-                            state.zygosity?.toLowerCase().includes('het')
+                            isHeterozygous(state.zygosity)
                                 ? 'Heterozygous'
-                                : state.zygosity?.toLowerCase().includes('hom')
+                                : isHomozygous(state.zygosity)
                                 ? 'Homozygous'
                                 : state.zygosity,
                         filter: 'multiSelect',

--- a/react/src/utils/index.ts
+++ b/react/src/utils/index.ts
@@ -4,26 +4,22 @@ import formatErrorMessage from './formatErrorMessage';
 import getKeys from './getKeys';
 import resolveAssembly from './resolveAssembly';
 import {
-    addAdditionalFieldsAndFormatNulls,
     calculateColumnWidth,
-    flattenBaseResults,
     isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
-    sortQueryResult,
+    prepareData,
 } from './tableHelpers';
 
 export {
-    addAdditionalFieldsAndFormatNulls,
     calculateColumnWidth,
     camelize,
     downloadCsv,
-    flattenBaseResults,
     formatErrorMessage,
     getKeys,
     isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
+    prepareData,
     resolveAssembly,
-    sortQueryResult,
 };

--- a/react/src/utils/index.ts
+++ b/react/src/utils/index.ts
@@ -8,6 +8,8 @@ import {
     isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
+    isHeterozygous,
+    isHomozygous,
     prepareData,
 } from './tableHelpers';
 
@@ -20,6 +22,8 @@ export {
     isCaseDetailsCollapsed,
     isHeader,
     isHeaderExpanded,
+    isHeterozygous,
+    isHomozygous,
     prepareData,
     resolveAssembly,
 };

--- a/react/src/utils/tableHelpers.ts
+++ b/react/src/utils/tableHelpers.ts
@@ -112,18 +112,12 @@ const sortQueryResult = (queryResult: VariantQueryDataResult[]) => {
     return sortedQueryResult;
 };
 
-export const isHeterozygous = (zygosity: String | null | undefined) => {
-    if (zygosity?.toLowerCase().includes('het')) {
-        return true;
-    }
-    return false;
+export const isHeterozygous = (zygosity: string | null | undefined) => {
+    return !!zygosity?.toLowerCase().includes('het');
 };
 
-export const isHomozygous = (zygosity: String | null | undefined) => {
-    if (zygosity?.toLowerCase().includes('hom')) {
-        return true;
-    }
-    return false;
+export const isHomozygous = (zygosity: string | null | undefined) => {
+    return !!zygosity?.toLowerCase().includes('hom');
 };
 
 // 1, Sort queryResult in ascending order according to variant's ref, alt, start, end.
@@ -147,7 +141,12 @@ export const prepareData = (
     sortedQueryResult.forEach(d => {
         const { ref, alt, start, end } = d.variant;
 
-        if (JSON.stringify(currVariant) !== JSON.stringify({ ref, alt, start, end })) {
+        if (
+            currVariant.ref !== ref ||
+            currVariant.alt !== alt ||
+            currVariant.start !== start ||
+            currVariant.end !== end
+        ) {
             if (uniqueVariantIndices.length) {
                 result
                     .slice(uniqueVariantIndices[uniqueVariantIndices.length - 1], currRowId)

--- a/react/src/utils/tableHelpers.ts
+++ b/react/src/utils/tableHelpers.ts
@@ -9,6 +9,7 @@ import {
 } from '../types';
 
 type Accessor = string | (() => JSX.Element) | ((state: any) => any);
+type Variant = Pick<VariantResponseFields, 'ref' | 'alt' | 'start' | 'end'>;
 
 export type FlattenedQueryResponse = Omit<IndividualResponseFields, 'info' | 'diseases'> &
     IndividualInfoFields & { contactInfo: string } & Omit<
@@ -22,6 +23,8 @@ export interface ResultTableColumns extends FlattenedQueryResponse {
     aaChange: string;
     emptyCaseDetails: string;
     emptyVariationDetails: string;
+    homozygousCount?: number;
+    heterozygousCount?: number;
     uniqueId: number;
 }
 
@@ -107,4 +110,78 @@ export const sortQueryResult = (queryResult: VariantQueryDataResult[]) => {
             a.variant.end - b.variant.end
     );
     return sortedQueryResult;
+};
+
+// 1, Sort queryResult in ascending order according to variant's ref, alt, start, end.
+// 2, Flatten data and compute values as needed (note that column display formatting function should not alter values for ease of export). Assign uniqueId, homozygousCount, heterozygousCount to each row.
+export const prepareData = (
+    queryResult: VariantQueryDataResult[]
+): [ResultTableColumns[], number[]] => {
+    const sortedQueryResult = sortQueryResult(queryResult);
+
+    const result: Array<ResultTableColumns> = [];
+
+    // contains indices of first encountered rows that represent unique variants.
+    const uniqueVariantIndices: Array<number> = [];
+
+    var currVariant = {} as Variant;
+    var currUniqueId = 0;
+    var currRowId = 0;
+    var currHomozygousCount = 0;
+    var currHeterozygousCount = 0;
+
+    sortedQueryResult.forEach(d => {
+        const { ref, alt, start, end } = d.variant;
+
+        if (JSON.stringify(currVariant) !== JSON.stringify({ ref, alt, start, end })) {
+            if (uniqueVariantIndices.length) {
+                result
+                    .slice(uniqueVariantIndices[uniqueVariantIndices.length - 1], currRowId)
+                    .forEach(row => {
+                        row.homozygousCount = currHomozygousCount;
+                        row.heterozygousCount = currHeterozygousCount;
+                    });
+            }
+
+            currHomozygousCount = 0;
+            currHeterozygousCount = 0;
+            currVariant = { ref, alt, start, end };
+            currUniqueId += 1;
+            uniqueVariantIndices.push(currRowId);
+        }
+
+        if (d.variant.callsets.length) {
+            result.push.apply(
+                result,
+                d.variant.callsets
+                    .filter(cs => cs.individualId === d.individual.individualId)
+                    .map(cs =>
+                        addAdditionalFieldsAndFormatNulls(
+                            {
+                                ...cs.info,
+                                ...flattenBaseResults(d),
+                            },
+                            currUniqueId
+                        )
+                    )
+            );
+            currRowId += d.variant.callsets.length;
+            d.variant.callsets.forEach(cs =>
+                cs.info.zygosity?.toLowerCase().includes('het')
+                    ? (currHeterozygousCount += 1)
+                    : cs.info.zygosity?.toLowerCase().includes('hom')
+                    ? (currHomozygousCount += 1)
+                    : {}
+            );
+        } else {
+            result.push(addAdditionalFieldsAndFormatNulls(flattenBaseResults(d), currUniqueId));
+            currRowId += 1;
+        }
+    });
+    result.slice(uniqueVariantIndices[uniqueVariantIndices.length - 1], currRowId).forEach(row => {
+        row.homozygousCount = currHomozygousCount;
+        row.heterozygousCount = currHeterozygousCount;
+    });
+
+    return [result, uniqueVariantIndices];
 };

--- a/react/src/utils/tableHelpers.ts
+++ b/react/src/utils/tableHelpers.ts
@@ -28,7 +28,7 @@ export interface ResultTableColumns extends FlattenedQueryResponse {
     uniqueId: number;
 }
 
-export const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQueryResponse => {
+const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQueryResponse => {
     const { contactInfo, source } = result;
     const { callsets, info: variantInfo, ...restVariant } = result.variant;
     const { diseases, info: individualInfo, ...restIndividual } = result.individual;
@@ -48,7 +48,7 @@ export const flattenBaseResults = (result: VariantQueryDataResult): FlattenedQue
     };
 };
 
-export const addAdditionalFieldsAndFormatNulls = (
+const addAdditionalFieldsAndFormatNulls = (
     results: FlattenedQueryResponse,
     uniqueId: number
 ): ResultTableColumns => {
@@ -101,7 +101,7 @@ export const isCaseDetailsCollapsed = (headers: HeaderGroup<ResultTableColumns>[
     return caseDetailsCol && !isHeaderExpanded(caseDetailsCol);
 };
 
-export const sortQueryResult = (queryResult: VariantQueryDataResult[]) => {
+const sortQueryResult = (queryResult: VariantQueryDataResult[]) => {
     const sortedQueryResult = [...queryResult].sort(
         (a, b) =>
             a.variant.ref.localeCompare(b.variant.ref) ||
@@ -110,6 +110,20 @@ export const sortQueryResult = (queryResult: VariantQueryDataResult[]) => {
             a.variant.end - b.variant.end
     );
     return sortedQueryResult;
+};
+
+export const isHeterozygous = (zygosity: String | null | undefined) => {
+    if (zygosity?.toLowerCase().includes('het')) {
+        return true;
+    }
+    return false;
+};
+
+export const isHomozygous = (zygosity: String | null | undefined) => {
+    if (zygosity?.toLowerCase().includes('hom')) {
+        return true;
+    }
+    return false;
 };
 
 // 1, Sort queryResult in ascending order according to variant's ref, alt, start, end.
@@ -167,9 +181,9 @@ export const prepareData = (
             );
             currRowId += d.variant.callsets.length;
             d.variant.callsets.forEach(cs =>
-                cs.info.zygosity?.toLowerCase().includes('het')
+                isHeterozygous(cs.info.zygosity)
                     ? (currHeterozygousCount += 1)
-                    : cs.info.zygosity?.toLowerCase().includes('hom')
+                    : isHomozygous(cs.info.zygosity)
                     ? (currHomozygousCount += 1)
                     : {}
             );


### PR DESCRIPTION
1. Added two columns to Variant Details group - `heterozygous count` and `homozygous count`. Each column represents how many heterozygous traits there are for a given variant.
2. Add alternating colors for the rows. Behavior under different scenarios: 
- When CaseDetails is not expanded, adjacent rows have different colors. 
- When the user expands case details, the same variant has the same color. 
- When the user clicks on a column to sort inside Case Details, now not all variants would be in the same group anymore. But the ones that do coincidentally group together would still have the same color.