### PR TITLE
React/Node: Resolve gene name

### DIFF
--- a/react/src/components/ComboBox.tsx
+++ b/react/src/components/ComboBox.tsx
@@ -4,6 +4,7 @@ import { FaCaretDown } from 'react-icons/fa';
 import styled from 'styled-components/macro';
 import { Background, Typography } from '../components';
 import { useClickAway } from '../hooks';
+import { GeneSelectionValue } from './GeneSearch';
 import Input, { InputProps } from './Input';
 import { Flex } from './Layout';
 import SelectableList, { SelectableListItem } from './SelectableList';
@@ -52,6 +53,10 @@ export const Header = styled(Flex)`
     flex-wrap: nowrap;
 `;
 
+/* Typeguard for type definition of option */
+const isGene = (arg: any): arg is GeneSelectionValue =>
+    typeof arg === 'object' && 'name' in arg && 'position' in arg;
+
 export default function ComboBox<T extends {}>({
     options,
     loading,
@@ -64,8 +69,6 @@ export default function ComboBox<T extends {}>({
     selection,
 }: ComboBoxProps<T>) {
     const [open, setOpen] = useState<Boolean>(false);
-
-    console.log(options);
 
     if (searchable && !onChange) {
         console.error('An onChange function is required for searchable comboboxes!');
@@ -100,7 +103,7 @@ export default function ComboBox<T extends {}>({
                     </>
                 )}
             </Header>
-            {options.length > 1 && typeof options[0].value !== 'string' && (
+            {options.length > 1 && isGene(options[0].value) && open && (
                 <Background
                     variant="success"
                     style={{
@@ -108,7 +111,7 @@ export default function ComboBox<T extends {}>({
                     }}
                 >
                     <Typography variant="subtitle" success bold>
-                        Multiple gene aliases are found. Please select the appropriate gene.
+                        {options.length} gene aliases are found. Please select the appropriate gene.
                     </Typography>
                 </Background>
             )}

--- a/react/src/components/ComboBox.tsx
+++ b/react/src/components/ComboBox.tsx
@@ -25,7 +25,6 @@ export const Wrapper = styled(Flex)`
     min-height: 38px;
     flex-wrap: wrap;
     flex-grow: 0;
-    max-width: 213px;
     position: relative;
     width: 100%;
 `;

--- a/react/src/components/ComboBox.tsx
+++ b/react/src/components/ComboBox.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, useState } from 'react';
 import { BsSearch } from 'react-icons/bs';
 import { FaCaretDown } from 'react-icons/fa';
 import styled from 'styled-components/macro';
+import { Background, Typography } from '../components';
 import { useClickAway } from '../hooks';
 import Input, { InputProps } from './Input';
 import { Flex } from './Layout';
@@ -64,6 +65,8 @@ export default function ComboBox<T extends {}>({
 }: ComboBoxProps<T>) {
     const [open, setOpen] = useState<Boolean>(false);
 
+    console.log(options);
+
     if (searchable && !onChange) {
         console.error('An onChange function is required for searchable comboboxes!');
     }
@@ -97,6 +100,18 @@ export default function ComboBox<T extends {}>({
                     </>
                 )}
             </Header>
+            {options.length > 1 && typeof options[0].value !== 'string' && (
+                <Background
+                    variant="success"
+                    style={{
+                        padding: '0rem 0.75rem',
+                    }}
+                >
+                    <Typography variant="subtitle" success bold>
+                        Multiple gene aliases are found. Please select the appropriate gene.
+                    </Typography>
+                </Background>
+            )}
             {open && (
                 <SelectableList
                     ref={ref}

--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -4,7 +4,7 @@ import { useFetchAutocompleteQuery } from '../apollo/hooks';
 import { AssemblyId } from '../types';
 import ComboBox from './ComboBox';
 import { SelectableListItem } from './SelectableList';
-
+import { Background, Typography } from '../components';
 interface HitPosition {
     chr: string;
     start: number;
@@ -76,9 +76,9 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
                                 position: `${e.chr}:${e.start}-${e.end}`,
                             },
                             id: i + eid,
-                            label: Array.isArray(hit.ensembl)
-                                ? `${hit.symbol.toUpperCase()} - ${genes.ensembl[eid].gene}`
-                                : hit.symbol.toUpperCase(),
+                            label: `${hit.symbol.toUpperCase()} (Chromosome: ${e.chr}, Start: ${
+                                e.start
+                            }, End: ${e.end})`,
                         }));
                 })
                 .flat(),
@@ -103,15 +103,29 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
     }, [geneName, assembly, autocompleteResults, formatAutocompleteOptions]);
 
     return (
-        <ComboBox
-            options={options}
-            loading={autocompleteLoading}
-            onChange={term => onChange(term)}
-            onSelect={(item: SelectionValue) => onSelect(item)}
-            placeholder="Gene Search"
-            searchable
-            value={geneName || ''}
-        />
+        <>
+            {options.length > 1 && (
+                <Background
+                    variant="success"
+                    style={{
+                        padding: '0rem 0.75rem',
+                    }}
+                >
+                    <Typography variant="subtitle" success bold>
+                        Multiple gene aliases are found. Please select the appropriate gene.
+                    </Typography>
+                </Background>
+            )}
+            <ComboBox
+                options={options}
+                loading={autocompleteLoading}
+                onChange={term => onChange(term)}
+                onSelect={(item: SelectionValue) => onSelect(item)}
+                placeholder="Gene Search"
+                searchable
+                value={geneName || ''}
+            />
+        </>
     );
 };
 

--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -23,7 +23,7 @@ interface AutocompleteResults {
         }[];
     };
 }
-interface SelectionValue {
+export interface GeneSelectionValue {
     ensemblId?: string;
     name: string;
     position: string;
@@ -32,7 +32,7 @@ interface SelectionValue {
 interface GeneSearchProps {
     assembly: AssemblyId;
     geneName: string;
-    onSelect: (gene: SelectionValue) => void;
+    onSelect: (gene: GeneSelectionValue) => void;
     onChange: (geneName: string) => void;
 }
 
@@ -40,7 +40,7 @@ const isCanonicalRegion = (chr: string) =>
     ['X', 'Y', ...Array.from({ length: 22 }, (_, i) => (i + 1).toString())].includes(chr);
 
 const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, onSelect }) => {
-    const [options, setOptions] = useState<SelectableListItem<SelectionValue>[]>([]);
+    const [options, setOptions] = useState<SelectableListItem<GeneSelectionValue>[]>([]);
 
     const [fetchAutocompleteResults, { data: autocompleteResults, loading: autocompleteLoading }] =
         useFetchAutocompleteQuery();
@@ -109,7 +109,7 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
                 options={options}
                 loading={autocompleteLoading}
                 onChange={term => onChange(term)}
-                onSelect={(item: SelectionValue) => onSelect(item)}
+                onSelect={(item: GeneSelectionValue) => onSelect(item)}
                 placeholder="Gene Search"
                 searchable
                 value={geneName || ''}

--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -24,7 +24,6 @@ interface AutocompleteResults {
     };
 }
 export interface GeneSelectionValue {
-    ensemblId?: string;
     name: string;
     position: string;
 }
@@ -72,7 +71,6 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
                             return {
                                 value: {
                                     name: genes.symbol.toUpperCase(),
-                                    ensemblId: '',
                                     position: `${e.chr}:${e.start}-${e.end}`,
                                 },
                                 id: i + eid,
@@ -104,17 +102,15 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
     }, [geneName, assembly, autocompleteResults, formatAutocompleteOptions]);
 
     return (
-        <>
-            <ComboBox
-                options={options}
-                loading={autocompleteLoading}
-                onChange={term => onChange(term)}
-                onSelect={(item: GeneSelectionValue) => onSelect(item)}
-                placeholder="Gene Search"
-                searchable
-                value={geneName || ''}
-            />
-        </>
+        <ComboBox
+            options={options}
+            loading={autocompleteLoading}
+            onChange={term => onChange(term)}
+            onSelect={(item: GeneSelectionValue) => onSelect(item)}
+            placeholder="Gene Search"
+            searchable
+            value={geneName || ''}
+        />
     );
 };
 

--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -46,8 +46,6 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
     const [fetchAutocompleteResults, { data: autocompleteResults, loading: autocompleteLoading }] =
         useFetchAutocompleteQuery();
 
-    console.log(autocompleteResults);
-
     const debouncedAutocompleteFetch = useAsyncDebounce(fetchAutocompleteResults, 500);
 
     const formatAutocompleteOptions = useCallback(

--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -4,7 +4,6 @@ import { useFetchAutocompleteQuery } from '../apollo/hooks';
 import { AssemblyId } from '../types';
 import ComboBox from './ComboBox';
 import { SelectableListItem } from './SelectableList';
-import { Background, Typography } from '../components';
 interface HitPosition {
     chr: string;
     start: number;
@@ -69,17 +68,19 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
 
                     return (is38 ? genomic_pos : genomic_pos_hg19)
                         .filter(g => isCanonicalRegion(g.chr))
-                        .map((e, eid) => ({
-                            value: {
-                                name: genes.symbol.toUpperCase(),
-                                ensemblId: genes.ensembl[eid].gene,
-                                position: `${e.chr}:${e.start}-${e.end}`,
-                            },
-                            id: i + eid,
-                            label: `${hit.symbol.toUpperCase()} (Chromosome: ${e.chr}, Start: ${
-                                e.start
-                            }, End: ${e.end})`,
-                        }));
+                        .map((e, eid) => {
+                            return {
+                                value: {
+                                    name: genes.symbol.toUpperCase(),
+                                    ensemblId: '',
+                                    position: `${e.chr}:${e.start}-${e.end}`,
+                                },
+                                id: i + eid,
+                                label: `${hit.symbol.toUpperCase()} (Chromosome: ${e.chr}, Start: ${
+                                    e.start
+                                }, End: ${e.end})`,
+                            };
+                        });
                 })
                 .flat(),
         []
@@ -104,18 +105,6 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
 
     return (
         <>
-            {options.length > 1 && (
-                <Background
-                    variant="success"
-                    style={{
-                        padding: '0rem 0.75rem',
-                    }}
-                >
-                    <Typography variant="subtitle" success bold>
-                        Multiple gene aliases are found. Please select the appropriate gene.
-                    </Typography>
-                </Background>
-            )}
             <ComboBox
                 options={options}
                 loading={autocompleteLoading}

--- a/react/src/components/Layout.tsx
+++ b/react/src/components/Layout.tsx
@@ -60,6 +60,7 @@ export const Column = styled(Flex)<FlexProps>`
 
 export const ButtonWrapper = styled(Flex)`
     display: inline-flex;
+    height: 125px;
     align-items: center;
 `;
 

--- a/react/src/components/SelectableList.tsx
+++ b/react/src/components/SelectableList.tsx
@@ -5,12 +5,12 @@ import { Checkbox } from './index';
 const StyledList = styled.ul`
     box-shadow: ${props => props.theme.boxShadow};
     padding: 0;
+    margin: 0;
     list-style-type: none;
     width: inherit;
-    margin-top: ${props => props.theme.space[5]};
     max-height: 200px;
     overflow: auto;
-    position: absolute;
+    // position: absolute;
     top: 20px;
     z-index: 998;
 `;

--- a/react/src/components/Typography.tsx
+++ b/react/src/components/Typography.tsx
@@ -5,6 +5,7 @@ import Theme from '../constants/theme';
 interface TypographyOverrides {
     bold?: boolean;
     error?: boolean;
+    success?: boolean;
 }
 
 type TagType = keyof typeof Theme.typography;
@@ -16,7 +17,12 @@ interface TypographyProps extends TypographyOverrides {
 const Component = styled.p<TypographyProps>`
     user-select: text;
     margin-inline-end: ${props => props.theme.space[2]};
-    color: ${props => (props.error ? props.theme.colors.error : 'inherit')};
+    color: ${props =>
+        props.error
+            ? props.theme.colors.error
+            : props.success
+            ? props.theme.colors.success
+            : 'inherit'};
     font-weight: ${(props: TypographyOverrides) => (props.bold ? 'bold' : 'normal')};
     font-size: ${props => {
         switch (props.variant) {

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -264,8 +264,8 @@ const VariantQueryPage: React.FC<{}> = () => {
                         >
                             Clear
                         </Button>
+                        <Column justifyContent="flex-start">{loading && <Spinner />}</Column>
                     </ButtonWrapper>
-                    <Column justifyContent="flex-start">{loading && <Spinner />}</Column>
                 </Flex>
             </Background>
             {[errorState.nodeErrors, errorState.networkErrors, errorState.graphQLErrors]

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -188,29 +188,34 @@ const VariantQueryPage: React.FC<{}> = () => {
                     </Column>
                 </Column>
             </Flex>
+
+            <Column
+                alignItems="flex-start"
+                style={{
+                    width: '50%',
+                }}
+            >
+                <Typography variant="subtitle" bold>
+                    Gene Name
+                </Typography>
+                <GeneSearch
+                    assembly={resolveAssembly(queryOptionsForm.assemblyId.value)}
+                    geneName={queryOptionsForm.gene.value}
+                    onChange={geneName => updateQueryOptionsForm({ gene: geneName, ensemblId: '' })}
+                    onSelect={val => {
+                        const { position, ensemblId } = val;
+                        updateQueryOptionsForm({
+                            gene: val.name,
+                            ensemblId,
+                            position,
+                        });
+                    }}
+                />
+                <ErrorText error={queryOptionsForm.gene.error} />
+            </Column>
+
             <Background variant="light">
                 <Flex alignItems="center">
-                    <Column alignItems="flex-start">
-                        <Typography variant="subtitle" bold>
-                            Gene Name
-                        </Typography>
-                        <GeneSearch
-                            assembly={resolveAssembly(queryOptionsForm.assemblyId.value)}
-                            geneName={queryOptionsForm.gene.value}
-                            onChange={geneName =>
-                                updateQueryOptionsForm({ gene: geneName, ensemblId: '' })
-                            }
-                            onSelect={val => {
-                                const { position, ensemblId } = val;
-                                updateQueryOptionsForm({
-                                    gene: val.name,
-                                    ensemblId,
-                                    position,
-                                });
-                            }}
-                        />
-                        <ErrorText error={queryOptionsForm.gene.error} />
-                    </Column>
                     <Column alignItems="flex-start">
                         <Typography variant="subtitle" bold>
                             Ensembl ID

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -32,18 +32,8 @@ const queryOptionsFormValidator: Validator<QueryOptionsFormState> = {
     assemblyId: {
         required: true,
     },
-    ensemblId: {
-        required: state => !state.gene.value,
-        rules: [
-            {
-                valid: (state: FormState<QueryOptionsFormState>) =>
-                    state.ensemblId.value.startsWith('ENSG00'),
-                error: 'Invalid ensembl ID format.',
-            },
-        ],
-    },
     gene: {
-        required: state => !state.ensemblId.value,
+        required: state => !state.gene.value,
         rules: [
             {
                 valid: (state: FormState<QueryOptionsFormState>) => state.gene.value.length > 3,
@@ -81,7 +71,6 @@ const queryOptionsFormValidator: Validator<QueryOptionsFormState> = {
 
 interface QueryOptionsFormState {
     assemblyId: string;
-    ensemblId: string;
     gene: string;
     maxFrequency: string;
     position: string;
@@ -106,7 +95,6 @@ const VariantQueryPage: React.FC<{}> = () => {
         useFormReducer<QueryOptionsFormState>(
             {
                 assemblyId: 'GRCh37',
-                ensemblId: '',
                 gene: '',
                 maxFrequency: '0.01',
                 sources: [],
@@ -123,7 +111,6 @@ const VariantQueryPage: React.FC<{}> = () => {
                     maxFrequency: +queryOptionsForm.maxFrequency.value,
                 },
                 gene: {
-                    ensemblId: queryOptionsForm.ensemblId.value,
                     geneName: queryOptionsForm.gene.value,
                     position: queryOptionsForm.position.value,
                 },
@@ -189,50 +176,31 @@ const VariantQueryPage: React.FC<{}> = () => {
                 </Column>
             </Flex>
 
-            <Column
-                alignItems="flex-start"
-                style={{
-                    width: '50%',
-                }}
-            >
-                <Typography variant="subtitle" bold>
-                    Gene Name
-                </Typography>
-                <GeneSearch
-                    assembly={resolveAssembly(queryOptionsForm.assemblyId.value)}
-                    geneName={queryOptionsForm.gene.value}
-                    onChange={geneName => updateQueryOptionsForm({ gene: geneName, ensemblId: '' })}
-                    onSelect={val => {
-                        const { position, ensemblId } = val;
-                        updateQueryOptionsForm({
-                            gene: val.name,
-                            ensemblId,
-                            position,
-                        });
-                    }}
-                />
-                <ErrorText error={queryOptionsForm.gene.error} />
-            </Column>
-
             <Background variant="light">
-                <Flex alignItems="center">
-                    <Column alignItems="flex-start">
+                <Flex alignItems="flex-start">
+                    <Column
+                        alignItems="flex-start"
+                        style={{
+                            width: '30%',
+                        }}
+                    >
                         <Typography variant="subtitle" bold>
-                            Ensembl ID
+                            Gene Name
                         </Typography>
-                        <Input
-                            variant="outlined"
-                            onChange={e =>
+                        <GeneSearch
+                            assembly={resolveAssembly(queryOptionsForm.assemblyId.value)}
+                            geneName={queryOptionsForm.gene.value}
+                            onChange={geneName => updateQueryOptionsForm({ gene: geneName })}
+                            onSelect={val => {
+                                const { position } = val;
                                 updateQueryOptionsForm({
-                                    ensemblId: e.currentTarget.value,
-                                    gene: '',
-                                })
-                            }
-                            value={queryOptionsForm.ensemblId.value}
+                                    gene: val.name,
+                                    position,
+                                });
+                            }}
                         />
-                        <ErrorText error={queryOptionsForm.ensemblId.error || ''} />
+                        <ErrorText error={queryOptionsForm.gene.error} />
                     </Column>
-
                     <Column alignItems="flex-start">
                         <Flex alignItems="center">
                             <Typography variant="subtitle" bold>
@@ -262,7 +230,6 @@ const VariantQueryPage: React.FC<{}> = () => {
                                 updateQueryOptionsForm({
                                     assemblyId: val as AssemblyId,
                                     gene: '',
-                                    ensemblId: '',
                                 })
                             }
                             options={['GRCh37', 'GRCh38'].map((a, id) => ({

--- a/react/src/types.ts
+++ b/react/src/types.ts
@@ -99,7 +99,6 @@ export interface VariantQueryInput {
 
 export interface GeneQueryInput {
     geneName: string;
-    ensemblId: string;
     position: string;
 }
 

--- a/server/src/resolvers/getVariantsResolver/adapters/remoteTestNodeAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/remoteTestNodeAdapter.ts
@@ -114,8 +114,11 @@ const getRemoteTestNodeQuery = async (args: QueryInput): Promise<VariantQueryRes
 
   try {
     console.log(process.env.TEST_NODE_URL);
+    console.log(
+      `${process.env.TEST_NODE_URL}?geneName=${args.input.gene.geneName}&assemblyId=${args.input.variant.assemblyId}`
+    );
     remoteTestNodeQueryResponse = await axios.get<StagerVariantQueryPayload[]>(
-      `${process.env.TEST_NODE_URL}?ensemblId=${args.input.gene.ensemblId}&assemblyId=${args.input.variant.assemblyId}`,
+      `${process.env.TEST_NODE_URL}?geneName=${args.input.gene.geneName}&assemblyId=${args.input.variant.assemblyId}`,
       {
         headers: { Authorization: `Bearer ${tokenResponse.data.access_token}` },
       }

--- a/server/src/resolvers/getVariantsResolver/adapters/remoteTestNodeAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/remoteTestNodeAdapter.ts
@@ -113,10 +113,6 @@ const getRemoteTestNodeQuery = async (args: QueryInput): Promise<VariantQueryRes
   let remoteTestNodeQueryError: RemoteTestNodeQueryError | null = null;
 
   try {
-    console.log(process.env.TEST_NODE_URL);
-    console.log(
-      `${process.env.TEST_NODE_URL}?geneName=${args.input.gene.geneName}&assemblyId=${args.input.variant.assemblyId}`
-    );
     remoteTestNodeQueryResponse = await axios.get<StagerVariantQueryPayload[]>(
       `${process.env.TEST_NODE_URL}?geneName=${args.input.gene.geneName}&assemblyId=${args.input.variant.assemblyId}`,
       {

--- a/server/src/typeDefs.ts
+++ b/server/src/typeDefs.ts
@@ -115,7 +115,6 @@ export default gql`
 
   input GeneQueryInput {
     geneName: String!
-    ensemblId: String
     position: String
   }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -99,7 +99,6 @@ export interface VariantQueryInput {
 
 export interface GeneQueryInput {
   geneName: string;
-  ensemblId: string;
   position: string;
 }
 

--- a/ssmp-schema.yml
+++ b/ssmp-schema.yml
@@ -61,8 +61,6 @@ components:
       properties:
         geneName:
           type: string
-        ensemblId:
-          type: string
     Individual:
       properties:
         individualId:

--- a/test-node/src/server.ts
+++ b/test-node/src/server.ts
@@ -37,12 +37,10 @@ const { STAGER_DB_HOST, STAGER_DB_PORT, STAGER_DB_USER, STAGER_DB_PASSWORD, STAG
 app.get(
   '/data',
   async (
-    {
-      query: { assemblyId, geneName },
-    }: Request<{ assemblyId: string; geneName: string }>,
+    { query: { assemblyId, geneName } }: Request<{ assemblyId: string; geneName: string }>,
     res
   ) => {
-    // res.json(createTestQueryResponse(geneName, ensemblId)); // uncomment and comment out 46 to get custom dummy data instead of querying "STAGER-like" databse
+    // res.json(createTestQueryResponse(geneName)); // uncomment and comment out 46 to get custom dummy data instead of querying "STAGER-like" databse
     // res.statusCode = 422;
     /// return res.json('invalid request');
     if (!assemblyId || !geneName) {
@@ -53,10 +51,7 @@ app.get(
       return res.json('Test node does not have hg38 variants!');
     }
 
-    const result = await getStagerData(
-      geneName as string,
-      assemblyId as string
-    );
+    const result = await getStagerData(geneName as string, assemblyId as string);
 
     if (!result) {
       res.statusCode = 404;
@@ -75,7 +70,6 @@ const getStagerData = async (geneName: string, assemblyId: string) => {
     password: STAGER_DB_PASSWORD,
     database: STAGER_DB,
   });
-
 
   let result;
 
@@ -120,7 +114,7 @@ const getStagerData = async (geneName: string, assemblyId: string) => {
 };
 
 /* create dummy data -- currently unused */
-export const createTestQueryResponse = (geneName: string, ensemblId: string) => {
+export const createTestQueryResponse = (geneName: string) => {
   return Array(50)
     .fill(null)
     .map(() => {
@@ -150,7 +144,7 @@ export const createTestQueryResponse = (geneName: string, ensemblId: string) => 
           info: {
             aaChanges: `Z[${ref}GC] > Y[${alt}GC]`,
             cDna: 'sampleCDA value',
-            geneName: geneName || ensemblId || 'GENENAME',
+            geneName: geneName || 'GENENAME',
             gnomadHet: Faker.datatype.float({ min: 0, max: 1, precision: 5 }),
             gnomadHom: Faker.helpers.randomize([0, 0, 0, 0, 0, 1, 2]),
             transcript: `ENSTFAKE${Faker.datatype.number({ min: 10000, max: 20000 })}`,


### PR DESCRIPTION
From discussion with our collaborators, we came to the conclusion that Ensembl ID is not a reliable point of reference for the identity of an actual gene, and should not be used in our search query to the `remote-test` and future `g4rd` node. This is due to ensembl IDs changing over time, and users not paying attention to which ensembl version they're using. 

To improve user's interpretability of our gene search, the following changes have been implemented: 
- Helper message informing users multiple aliases are available
- Specified chromosome, start, and end position since one gene name can refer to completely different genes on different chromosomes.
- Removed Ensembl ID from UI.
- Removed Ensembl ID as a search param to `remote-test` endpoint.
- Modified `remote-test` endpoint to only take in gene name and assembly.
- Added check for whether a gene is canonical. To elaborate, a gene such as `ABHD16A` refers to 6 chromosomes, but 5 of them is in regions that are major histocompatibility. These regions are highly polymorphic (highly variable between individuals), not representative of many individuals, and therefore should be removed from search. 