### PR TITLE
React: Add drag handle to invisible columns in Customize Columns modal

### DIFF
--- a/react/src/components/DragHandle.tsx
+++ b/react/src/components/DragHandle.tsx
@@ -19,22 +19,22 @@ interface DragHandleProps {
 }
 
 const DragHandle: React.FC<DragHandleProps> = ({ isVisible, dragHandleProps }) => {
-    return (
-        <>
-            {isVisible && (
+    if (isVisible)
+        return (
+            <div style={{ paddingRight: 40 }}>
                 <Component {...dragHandleProps} isVisible={isVisible}>
                     <RiDragMove2Fill />
                 </Component>
-            )}
-
-            {!isVisible && (
-                <Tooltip helperText="Only visible columns are draggable.">
-                    <Component {...dragHandleProps} isVisible={isVisible}>
-                        <MdDragHandle />
-                    </Component>
-                </Tooltip>
-            )}
-        </>
+            </div>
+        );
+    return (
+        <div style={{ paddingRight: 40 }}>
+            <Tooltip helperText="Only visible columns are draggable.">
+                <Component {...dragHandleProps} isVisible={isVisible}>
+                    <MdDragHandle />
+                </Component>
+            </Tooltip>
+        </div>
     );
 };
 

--- a/react/src/components/DragHandle.tsx
+++ b/react/src/components/DragHandle.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
+import { MdDragHandle } from 'react-icons/md';
+import { RiDragMove2Fill } from 'react-icons/ri';
+import styled from 'styled-components/macro';
+import Tooltip from './Tooltip';
+
+interface ComponentProps {
+    isVisible: boolean;
+}
+
+const Component = styled.span<ComponentProps>`
+    color: ${props => (props.isVisible ? props.theme.colors.primary : 'grey')};
+`;
+
+interface DragHandleProps {
+    isVisible: boolean;
+    dragHandleProps: DraggableProvidedDragHandleProps | undefined;
+}
+
+const DragHandle: React.FC<DragHandleProps> = ({ isVisible, dragHandleProps }) => {
+    return (
+        <>
+            {isVisible && (
+                <Component {...dragHandleProps} isVisible={isVisible}>
+                    <RiDragMove2Fill />
+                </Component>
+            )}
+
+            {!isVisible && (
+                <Tooltip helperText="Only visible columns are draggable.">
+                    <Component {...dragHandleProps} isVisible={isVisible}>
+                        <MdDragHandle />
+                    </Component>
+                </Tooltip>
+            )}
+        </>
+    );
+};
+
+export default DragHandle;

--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -93,7 +93,7 @@ export default function ColumnVisibilityModal<T extends {}>({
                                                             alignItems="center"
                                                             fullWidth={true}
                                                         >
-                                                            <div style={{ paddingLeft: 20 }}>
+                                                            <div style={{ paddingLeft: 20, background: "white" }}>
                                                                 <Checkbox
                                                                     label={c.Header as string}
                                                                     checked={c.isVisible}

--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -124,14 +124,12 @@ export default function ColumnVisibilityModal<T extends {}>({
                                                                 />
                                                             </div>
 
-                                                            <div style={{ paddingRight: 40 }}>
-                                                                <DragHandle
-                                                                    isVisible={c.isVisible}
-                                                                    dragHandleProps={
-                                                                        provided.dragHandleProps
-                                                                    }
-                                                                />
-                                                            </div>
+                                                            <DragHandle
+                                                                isVisible={c.isVisible}
+                                                                dragHandleProps={
+                                                                    provided.dragHandleProps
+                                                                }
+                                                            />
                                                         </Flex>
                                                     )}
                                                 </Draggable>

--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 import { BsFillEyeFill, BsFillEyeSlashFill } from 'react-icons/bs';
-import { MdDragHandle } from 'react-icons/md';
 import { ColumnInstance, HeaderGroup, UseTableInstanceProps } from 'react-table';
 import { camelize } from '../../utils';
-import { Button, Checkbox, Flex, InlineFlex, Modal } from '../index';
+import { Button, Checkbox, DragHandle, Flex, InlineFlex, Modal } from '../index';
 import { IconPadder } from './Table.styles';
 
 interface ColumnVisibilityModalProps<T extends object>
@@ -125,18 +124,14 @@ export default function ColumnVisibilityModal<T extends {}>({
                                                                 />
                                                             </div>
 
-                                                            {c.isVisible && (
-                                                                <div
-                                                                    {...provided.dragHandleProps}
-                                                                    style={{
-                                                                        justifyContent: 'flex-end',
-                                                                        display: 'flex',
-                                                                        paddingRight: '40px',
-                                                                    }}
-                                                                >
-                                                                    <MdDragHandle />
-                                                                </div>
-                                                            )}
+                                                            <div style={{ paddingRight: 40 }}>
+                                                                <DragHandle
+                                                                    isVisible={c.isVisible}
+                                                                    dragHandleProps={
+                                                                        provided.dragHandleProps
+                                                                    }
+                                                                />
+                                                            </div>
                                                         </Flex>
                                                     )}
                                                 </Draggable>

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -4,6 +4,7 @@ import Checkbox from './Checkbox';
 import Chip from './Chip';
 import ComboBox from './ComboBox';
 import Divider from './Divider';
+import DragHandle from './DragHandle';
 import ErrorProvider, {
     clearError,
     ErrorContext,
@@ -42,6 +43,7 @@ export {
     ComboBox,
     Container,
     Divider,
+    DragHandle,
     ErrorContext,
     ErrorProvider,
     ErrorFallback,


### PR DESCRIPTION
Closes #224 
![Screen Shot 2022-04-06 at 4 06 17 PM](https://user-images.githubusercontent.com/56279639/162061722-b1da49c5-ed68-4d5a-a81d-722b89d7c5d1.png)


In the Customize Columns modal, make the drag handle purple for visible columns, and make the drag handle grey for invisible columns. It is difficult to distinguish different colors so the different drag handle icons are used for visible and invisible columns.

When a user hovers above the grey drag icon, show a hover message "Only visible columns are draggable". That way users know they have to turn on the columns first before dragging them. 