### PR TITLE
Resolve assemblyId in variant data queries.

### DIFF
--- a/react/src/apollo/hooks/useFetchVariantsQuery.ts
+++ b/react/src/apollo/hooks/useFetchVariantsQuery.ts
@@ -8,6 +8,7 @@ const fetchVariantsQuery = gql`
             data {
                 variant {
                     alt
+                    assemblyId
                     callsets {
                         callsetId
                         individualId

--- a/server/src/resolvers/getVariantsResolver/adapters/g4rdAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/g4rdAdapter.ts
@@ -73,6 +73,9 @@ const getG4rdNodeQuery = async ({
   const url = `${process.env.G4RD_URL}/rest/variants/match`;
   const { position, ...gene } = geneInput;
   variant.assemblyId = 'GRCh37';
+  // For g4rd node, assemblyId is a required field as specified in this sample request:
+  // https://github.com/ccmbioinfo/report-scripts/blob/master/docs/phenotips-api.md#matching-endpoint
+  // assemblyId is set to be GRCh37 because g4rd node only contains data in assembly GRCh37.
   try {
     G4RDVariantQueryResponse = await axios.post<G4RDVariantQueryResult>(
       url,

--- a/server/src/resolvers/getVariantsResolver/adapters/g4rdAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/g4rdAdapter.ts
@@ -72,6 +72,7 @@ const getG4rdNodeQuery = async ({
   }
   const url = `${process.env.G4RD_URL}/rest/variants/match`;
   const { position, ...gene } = geneInput;
+  variant.assemblyId = 'GRCh37';
   try {
     G4RDVariantQueryResponse = await axios.post<G4RDVariantQueryResult>(
       url,

--- a/server/src/resolvers/getVariantsResolver/adapters/remoteTestNodeAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/remoteTestNodeAdapter.ts
@@ -114,7 +114,7 @@ const getRemoteTestNodeQuery = async (args: QueryInput): Promise<VariantQueryRes
 
   try {
     remoteTestNodeQueryResponse = await axios.get<StagerVariantQueryPayload[]>(
-      `${process.env.TEST_NODE_URL}?geneName=${args.input.gene.geneName}&assemblyId=${args.input.variant.assemblyId}`,
+      `${process.env.TEST_NODE_URL}?geneName=${args.input.gene.geneName}`,
       {
         headers: { Authorization: `Bearer ${tokenResponse.data.access_token}` },
       }

--- a/test-node/src/server.ts
+++ b/test-node/src/server.ts
@@ -38,30 +38,21 @@ const {
   TEST_DATA_DB,
 } = process.env;
 
-app.get(
-  '/data',
-  async (
-    { query: { assemblyId, geneName } }: Request<{ assemblyId: string; geneName: string }>,
-    res
-  ) => {
-    if (!assemblyId || !geneName) {
-      res.statusCode = 422;
-      return res.json(`invalid request (assemblyId: ${assemblyId}, geneName: ${geneName})`);
-    } else if (!(assemblyId as string).includes('37')) {
-      res.statusCode = 422;
-      return res.json('Test node does not have hg38 variants!');
-    }
-
-    const result = await getStagerData(geneName as string);
-
-    if (!result) {
-      res.statusCode = 404;
-      return res.json('There are no variants matching your search criteria.');
-    } else {
-      return res.json(result);
-    }
+app.get('/data', async ({ query: { geneName } }: Request<{ geneName: string }>, res) => {
+  if (!geneName) {
+    res.statusCode = 422;
+    return res.json(`invalid request (geneName: ${geneName})`);
   }
-);
+
+  const result = await getStagerData(geneName as string);
+
+  if (!result) {
+    res.statusCode = 404;
+    return res.json('There are no variants matching your search criteria.');
+  } else {
+    return res.json(result);
+  }
+});
 
 const getStagerData = async (geneName: string) => {
   const connection = await mysql.createConnection({


### PR DESCRIPTION
- For remote-test node, remove `assemblyId` in the request. 
- For g4rd node, `assemblyId` is a required field as specified in the sample request [here](https://github.com/ccmbioinfo/report-scripts/blob/master/docs/phenotips-api.md#matching-endpoint). Set `assemblyId` to be `GRCh37` because `g4rd` only contains data in assembly `GRCh37`. 
- Add `assemblyId` in `useFetchVariantsQuery.ts` in order to get the assembly of the returned variant data.

Reason for these modifications:
The desired behaviour is as follows. No matter which assembly the user specifies, we want to return **all variant data in all assemblies** and then perform liftOver if necessary. Thus, we do not want to send assemblyId to the data source nodes. 
