### PR TITLE
Bug fix: Add working directory for local dev

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       context: server
       target: dev
     image: ghcr.io/ccmbioinfo/ssmp:dev
+    working_dir: /usr/src/app
     init: true
     command: yarn start
     ports:
@@ -85,8 +86,8 @@ services:
       MYSQL_USER: "${TEST_DATA_DB_USER}"
       MYSQL_PASSWORD: "${TEST_DATA_DB_PASSWORD}"
       MYSQL_ROOT_PASSWORD: "${TEST_DATA_DB_ROOT_PASSWORD}"
-    ports: 
-      - ${TEST_DATA_DB_PORT}:3306 
+    ports:
+      - ${TEST_DATA_DB_PORT}:3306
     volumes:
       - ${TEST_DATA_DATA_VOLUME}:/var/lib/mysql
   keycloak:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
       context: server
       target: dev
     image: ghcr.io/ccmbioinfo/ssmp:dev
-    working_dir: /usr/src/app
     init: true
     command: yarn start
     ports:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,10 +12,10 @@ FROM node:16-slim AS dev
 RUN  apt-get update && apt-get install -y libcurl4 && rm -rf /var/lib/apt/lists/*
 COPY --from=download /var/tmp/liftOver /usr/local/bin 
 COPY --from=download --chown=node:node /var/tmp/*.over.chain /home/node/
+WORKDIR /usr/src/app
 
 # This layer is shared between the builder and production stages
 FROM dev AS base
-WORKDIR /usr/src/app
 COPY package*.json yarn.lock ./
 RUN yarn --prod
 


### PR DESCRIPTION
The working directory is not specified for the `dev` image in `server/Dockerfile`, thus, `docker-compose up ssmp-server` will fail because the command `yarn start` in `docker-compose.yaml` could not find `package.json`

In this PR, `working_dir: /usr/src/app` is added before running the command `yarn start`. 