### PR TITLE
LiftOver implementation 

### DIFF
--- a/react/src/apollo/hooks/useFetchVariantsQuery.ts
+++ b/react/src/apollo/hooks/useFetchVariantsQuery.ts
@@ -9,6 +9,7 @@ const fetchVariantsQuery = gql`
                 variant {
                     alt
                     assemblyId
+                    assemblyIdCurrent
                     callsets {
                         callsetId
                         individualId

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -174,6 +174,18 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         width: getColumnWidth('Alt'),
                     },
                     {
+                        accessor: 'assemblyId',
+                        id: 'originalAssembly',
+                        Header: 'Original Assembly',
+                        width: getColumnWidth('Original Assembly'),
+                    },
+                    {
+                        accessor: 'assemblyIdCurrent',
+                        id: 'currentAssembly',
+                        Header: 'Current Assembly',
+                        width: getColumnWidth('Current Assembly'),
+                    },
+                    {
                         accessor: 'source',
                         filter: 'singleSelect',
                         id: 'source',

--- a/react/src/types.ts
+++ b/react/src/types.ts
@@ -33,6 +33,7 @@ export type AssemblyId = 'gnomAD_GRCh37' | '38' | 'GRCh37' | 'GRCh38' | '37' | '
 export interface VariantResponseFields {
     alt: string;
     assemblyId: AssemblyId;
+    assemblyIdCurrent: AssemblyId;
     callsets: CallSet[];
     end: number;
     info?: Maybe<VariantResponseInfoFields>;

--- a/server/src/resolvers/getVariantsResolver/adapters/g4rdAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/g4rdAdapter.ts
@@ -15,6 +15,7 @@ import {
   IndividualInfoFields,
 } from '../../../types';
 import { getFromCache, putInCache } from '../../../utils/cache';
+import resolveAssembly from '../utils/resolveAssembly';
 
 /* eslint-disable camelcase */
 
@@ -181,6 +182,7 @@ export const transformG4RDQueryResponse: ResultTransformer<G4RDVariantQueryResul
 
   return (variantResponse.results || []).map(r => {
     /* eslint-disable @typescript-eslint/no-unused-vars */
+    r.variant.assemblyId = resolveAssembly(r.variant.assemblyId);
     const { chromosome, ...restVariant } = r.variant;
     const { individual, contactInfo } = r;
 

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -85,7 +85,7 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
     dataForAnnotation = liftoverResults.dataForAnnotation;
     annotationPosition = liftoverResults.annotationPosition;
   }
-  
+
   // Cadd annotations for data in user requested assemblyId
   let data: VariantQueryDataResult[] = [];
   const caddAnnotationsPromise = fetchCaddAnnotations(annotationPosition, assemblyId);
@@ -101,6 +101,7 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
   // gnomAD annotations TODO: gnomAD annotations for GRCh38 are not available yet.
   data = await annotateGnomad(data ?? dataForAnnotation);
 
+  // return unmapped variants if there's any
   if (unliftedVariants.length) {
     data = data.concat(unliftedVariants);
   }

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -97,7 +97,9 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
   }
 
   // gnomAD annotations TODO: gnomAD annotations for GRCh38 are not available yet.
-  data = await annotateGnomad(data ?? dataForAnnotation);
+  if (assemblyId === 'GRCh37'){
+    data = await annotateGnomad(data ?? dataForAnnotation);
+  }
 
   // return unmapped variants if there's any
   if (unliftedVariants.length) {

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -13,7 +13,6 @@ import fetchCaddAnnotations from './utils/fetchCaddAnnotations';
 import annotateCadd from './utils/annotateCadd';
 import annotateGnomad from './utils/annotateGnomad';
 import liftover from './utils/liftOver';
-import resolveAssembly from './utils/resolveAssembly';
 import getG4rdNodeQuery from './adapters/g4rdAdapter';
 
 const getVariants = async (parent: any, args: QueryInput): Promise<CombinedVariantQueryResponse> =>
@@ -70,8 +69,7 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
   const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId);
   // filter data that are already in user requested assemlbyId
   let dataForAnnotation = combinedResults.filter(v => {
-    if (resolveAssembly(v.variant.assemblyId) === assemblyId) {
-      v.variant.assemblyId = assemblyId;
+    if (v.variant.assemblyId === assemblyId) {
       v.variant.assemblyIdCurrent = assemblyId;
       return true;
     } else return false;
@@ -97,7 +95,7 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
   }
 
   // gnomAD annotations TODO: gnomAD annotations for GRCh38 are not available yet.
-  if (assemblyId === 'GRCh37'){
+  if (assemblyId === 'GRCh37') {
     data = await annotateGnomad(data ?? dataForAnnotation);
   }
 

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -81,9 +81,7 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
   // perform liftOver if needed
   if (dataForLiftover.length) {
     const liftoverResults = await liftover(dataForAnnotation, dataForLiftover, assemblyId);
-    unliftedVariants = liftoverResults.unliftedVariants;
-    dataForAnnotation = liftoverResults.dataForAnnotation;
-    annotationPosition = liftoverResults.annotationPosition;
+    ({ unliftedVariants, dataForAnnotation, annotationPosition } = liftoverResults);
   }
 
   // Cadd annotations for data in user requested assemblyId

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -12,7 +12,13 @@ import getRemoteTestNodeQuery from './adapters/remoteTestNodeAdapter';
 import fetchCaddAnnotations from './utils/fetchCaddAnnotations';
 import annotateCadd from './utils/annotateCadd';
 import annotateGnomad from './utils/annotateGnomad';
+import resolveAssembly from './utils/resolveAssembly';
 import getG4rdNodeQuery from './adapters/g4rdAdapter';
+
+const promiseExec = require('util').promisify(require('child_process').exec);
+const tmpdir = require('os').tmpdir;
+const fs = require('fs/promises');
+const path = require('path');
 
 const getVariants = async (parent: any, args: QueryInput): Promise<CombinedVariantQueryResponse> =>
   await resolveVariantQuery(args);
@@ -30,18 +36,17 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
     },
   } = args;
 
-  // fetch CADD and data in parallel
-  const caddAnnotationsPromise = fetchCaddAnnotations(position, assemblyId);
+  let annotationPosition = position;
 
+  // fetch data
   const queries = sources.map(source => buildSourceQuery(source, args));
-
-  const settled = await Promise.allSettled([caddAnnotationsPromise, ...queries]);
+  const settledQueries = await Promise.allSettled([...queries]);
 
   const errors: SourceError[] = [];
-  const combinedResults: VariantQueryDataResult[] = [];
+  const combinedResults: VariantQueryDataResult[] = [];  
 
   /* inspect variant results and combine if no errors */
-  settled.forEach(response => {
+  settledQueries.forEach(response => {
     if (
       response.status === 'fulfilled' &&
       isVariantQuery(response.value) &&
@@ -65,20 +70,112 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
     }
   });
 
-  // once variants are merged, handle annotations
-  const caddAannotations = settled.find(
+  // filter data to send to liftover. 
+  const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId); // datasets that need liftover
+  const dataForAnnotation = combinedResults.filter(v =>                        // datasets that do not need liftover, but are ready for annotation 
+    {if (resolveAssembly(v.variant.assemblyId) === assemblyId){
+      v.variant.assemblyId = assemblyId;
+      v.variant.assemblyIdCurrent = assemblyId;
+      return true;
+  }else return false;});
+  const unliftedVariants: VariantQueryDataResult[] = [];              // datasets that failed liftover, can't be sent for annotation. 
+
+  // Perform liftOver for liftOverDatasets
+  if (dataForLiftover.length){
+    // Get a bedstring of all data variants in JSON format. Note that position format is 1-based and BED format is half-open 0-based: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
+    const bedstring = dataForLiftover
+      .map(v => `chr${v.variant.referenceName}\t${v.variant.start - 1}\t${v.variant.end}`)
+      .join('\n');
+
+    const createTmpFile = async () => {
+      const filename = Math.random().toString(36).slice(2);
+      const dir = await fs.mkdtemp(path.join(tmpdir(), 'liftover-'));
+      return path.join(dir, filename);
+    };
+
+    const lifted = await createTmpFile();
+    const unlifted = await createTmpFile();
+    const bedfile = await createTmpFile();
+    await fs.writeFile(bedfile, bedstring);
+    let chain: string;
+    if (assemblyId === "GRCh37"){
+      chain = '/home/node/hg38ToHg19.over.chain';
+    } else{
+      chain = '/home/node/hg19ToHg38.over.chain';
+    }
+    await promiseExec(`liftOver ${bedfile} ${chain} ${lifted} ${unlifted}`);
+    const _liftedVars = await fs.readFile(lifted);
+    const _unliftedVars = await fs.readFile(unlifted);
+    // We assume that the variants are SNV for now, so parseBed is only taking the field "start" because "start" == "end" for SNV.
+    const parseBed = (bed: String) =>
+      bed
+        .split('\n')
+        .filter(l => !!l && !l.startsWith('#'))
+        .map(v => v.split('\t')[1]);
+    const parseBedEnd = (bed: String) =>
+      bed
+        .split('\n')
+        .filter(l => !!l && !l.startsWith('#'))
+        .map(v => v.split('\t')[2]);
+    const liftedVars = parseBed(_liftedVars.toString());
+    const unliftedVars = parseBed(_unliftedVars.toString());
+    const liftedVarsEnd = parseBedEnd(_liftedVars.toString());
+    
+
+    // mergeResults
+    const unliftedMap: { [key: string]: boolean } = unliftedVars.reduce(
+      (acc, curr) => ({ ...acc, [curr]: true }),
+      {}
+    );
+    dataForLiftover.forEach((v,i)=>{
+      if (unliftedMap[(v.variant.start - 1).toString()]) {
+        v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
+        v.variant.assemblyIdCurrent = v.variant.assemblyId;
+        unliftedVariants.push(v);
+      } else {
+        v.variant.start = Number(liftedVars[i]) + 1; // Convert from BED format (half-open zero-based) to position format (1-based). We assume that the variants are SNV for now.
+        v.variant.end = Number(liftedVarsEnd[i]);
+        v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
+        v.variant.assemblyIdCurrent = assemblyId;
+        dataForAnnotation.push(v);
+      }
+    })
+
+    // get position start end for annotation, only those that correspond to user input assembly 
+    let geneStart = Infinity;
+    let geneEnd = 0;
+
+    dataForAnnotation.forEach(result => {
+      if (result.variant.start < geneStart) {
+        geneStart = result.variant.start;
+      }
+      if (result.variant.end > geneEnd) {
+        geneEnd = result.variant.end;
+      }
+    });
+
+    annotationPosition = `${dataForAnnotation[0].variant.referenceName}:${geneStart}-${geneEnd}`;
+  }
+  // Cadd Annotations
+  const caddAnnotationsPromise = fetchCaddAnnotations(annotationPosition, assemblyId);
+  const settledCadd = await Promise.allSettled([caddAnnotationsPromise]);
+
+  // Handle annotations
+  const caddAannotations = settledCadd.find(
     res => res.status === 'fulfilled' && !isVariantQuery(res.value)
   ) as PromiseFulfilledResult<CADDAnnotationQueryResponse>;
 
-  let data;
+  let data: VariantQueryDataResult[] = []; 
 
   if (!!caddAannotations && !caddAannotations.value.error) {
-    data = annotateCadd(combinedResults, caddAannotations.value.data);
+    data = annotateCadd(dataForAnnotation, caddAannotations.value.data);
   }
 
-  data = await annotateGnomad(data ?? combinedResults);
-
-  return { errors, data };
+  data = await annotateGnomad(data ?? dataForAnnotation);
+  if (unliftedVariants.length){
+    data = data.concat(unliftedVariants);
+  }
+  return { errors, data};
 };
 
 const buildSourceQuery = (source: string, args: QueryInput): Promise<VariantQueryResponse> => {

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -12,13 +12,9 @@ import getRemoteTestNodeQuery from './adapters/remoteTestNodeAdapter';
 import fetchCaddAnnotations from './utils/fetchCaddAnnotations';
 import annotateCadd from './utils/annotateCadd';
 import annotateGnomad from './utils/annotateGnomad';
+import liftover from './utils/liftOver';
 import resolveAssembly from './utils/resolveAssembly';
 import getG4rdNodeQuery from './adapters/g4rdAdapter';
-
-const promiseExec = require('util').promisify(require('child_process').exec);
-const tmpdir = require('os').tmpdir;
-const fs = require('fs/promises');
-const path = require('path');
 
 const getVariants = async (parent: any, args: QueryInput): Promise<CombinedVariantQueryResponse> =>
   await resolveVariantQuery(args);
@@ -43,7 +39,7 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
   const settledQueries = await Promise.allSettled([...queries]);
 
   const errors: SourceError[] = [];
-  const combinedResults: VariantQueryDataResult[] = [];  
+  const combinedResults: VariantQueryDataResult[] = [];
 
   /* inspect variant results and combine if no errors */
   settledQueries.forEach(response => {
@@ -70,112 +66,45 @@ const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQue
     }
   });
 
-  // filter data to send to liftover. 
-  const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId); // datasets that need liftover
-  const dataForAnnotation = combinedResults.filter(v =>                        // datasets that do not need liftover, but are ready for annotation 
-    {if (resolveAssembly(v.variant.assemblyId) === assemblyId){
+  // filter data that are not in user requested assemblyId
+  const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId);
+  // filter data that are already in user requested assemlbyId
+  let dataForAnnotation = combinedResults.filter(v => {
+    if (resolveAssembly(v.variant.assemblyId) === assemblyId) {
       v.variant.assemblyId = assemblyId;
       v.variant.assemblyIdCurrent = assemblyId;
       return true;
-  }else return false;});
-  const unliftedVariants: VariantQueryDataResult[] = [];              // datasets that failed liftover, can't be sent for annotation. 
+    } else return false;
+  });
+  let unliftedVariants: VariantQueryDataResult[] = [];
 
-  // Perform liftOver for liftOverDatasets
-  if (dataForLiftover.length){
-    // Get a bedstring of all data variants in JSON format. Note that position format is 1-based and BED format is half-open 0-based: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
-    const bedstring = dataForLiftover
-      .map(v => `chr${v.variant.referenceName}\t${v.variant.start - 1}\t${v.variant.end}`)
-      .join('\n');
-
-    const createTmpFile = async () => {
-      const filename = Math.random().toString(36).slice(2);
-      const dir = await fs.mkdtemp(path.join(tmpdir(), 'liftover-'));
-      return path.join(dir, filename);
-    };
-
-    const lifted = await createTmpFile();
-    const unlifted = await createTmpFile();
-    const bedfile = await createTmpFile();
-    await fs.writeFile(bedfile, bedstring);
-    let chain: string;
-    if (assemblyId === "GRCh37"){
-      chain = '/home/node/hg38ToHg19.over.chain';
-    } else{
-      chain = '/home/node/hg19ToHg38.over.chain';
-    }
-    await promiseExec(`liftOver ${bedfile} ${chain} ${lifted} ${unlifted}`);
-    const _liftedVars = await fs.readFile(lifted);
-    const _unliftedVars = await fs.readFile(unlifted);
-    // We assume that the variants are SNV for now, so parseBed is only taking the field "start" because "start" == "end" for SNV.
-    const parseBed = (bed: String) =>
-      bed
-        .split('\n')
-        .filter(l => !!l && !l.startsWith('#'))
-        .map(v => v.split('\t')[1]);
-    const parseBedEnd = (bed: String) =>
-      bed
-        .split('\n')
-        .filter(l => !!l && !l.startsWith('#'))
-        .map(v => v.split('\t')[2]);
-    const liftedVars = parseBed(_liftedVars.toString());
-    const unliftedVars = parseBed(_unliftedVars.toString());
-    const liftedVarsEnd = parseBedEnd(_liftedVars.toString());
-    
-
-    // mergeResults
-    const unliftedMap: { [key: string]: boolean } = unliftedVars.reduce(
-      (acc, curr) => ({ ...acc, [curr]: true }),
-      {}
-    );
-    dataForLiftover.forEach((v,i)=>{
-      if (unliftedMap[(v.variant.start - 1).toString()]) {
-        v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
-        v.variant.assemblyIdCurrent = v.variant.assemblyId;
-        unliftedVariants.push(v);
-      } else {
-        v.variant.start = Number(liftedVars[i]) + 1; // Convert from BED format (half-open zero-based) to position format (1-based). We assume that the variants are SNV for now.
-        v.variant.end = Number(liftedVarsEnd[i]);
-        v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
-        v.variant.assemblyIdCurrent = assemblyId;
-        dataForAnnotation.push(v);
-      }
-    })
-
-    // get position start end for annotation, only those that correspond to user input assembly 
-    let geneStart = Infinity;
-    let geneEnd = 0;
-
-    dataForAnnotation.forEach(result => {
-      if (result.variant.start < geneStart) {
-        geneStart = result.variant.start;
-      }
-      if (result.variant.end > geneEnd) {
-        geneEnd = result.variant.end;
-      }
-    });
-
-    annotationPosition = `${dataForAnnotation[0].variant.referenceName}:${geneStart}-${geneEnd}`;
+  // perform liftOver if needed
+  if (dataForLiftover.length) {
+    const liftoverResults = await liftover(dataForAnnotation, dataForLiftover, assemblyId);
+    unliftedVariants = liftoverResults.unliftedVariants;
+    dataForAnnotation = liftoverResults.dataForAnnotation;
+    annotationPosition = liftoverResults.annotationPosition;
   }
-  // Cadd Annotations
+  
+  // Cadd annotations for data in user requested assemblyId
+  let data: VariantQueryDataResult[] = [];
   const caddAnnotationsPromise = fetchCaddAnnotations(annotationPosition, assemblyId);
   const settledCadd = await Promise.allSettled([caddAnnotationsPromise]);
-
-  // Handle annotations
   const caddAannotations = settledCadd.find(
     res => res.status === 'fulfilled' && !isVariantQuery(res.value)
   ) as PromiseFulfilledResult<CADDAnnotationQueryResponse>;
-
-  let data: VariantQueryDataResult[] = []; 
 
   if (!!caddAannotations && !caddAannotations.value.error) {
     data = annotateCadd(dataForAnnotation, caddAannotations.value.data);
   }
 
+  // gnomAD annotations TODO: gnomAD annotations for GRCh38 are not available yet.
   data = await annotateGnomad(data ?? dataForAnnotation);
-  if (unliftedVariants.length){
+
+  if (unliftedVariants.length) {
     data = data.concat(unliftedVariants);
   }
-  return { errors, data};
+  return { errors, data };
 };
 
 const buildSourceQuery = (source: string, args: QueryInput): Promise<VariantQueryResponse> => {

--- a/server/src/resolvers/getVariantsResolver/utils/fetchCaddAnnotations.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/fetchCaddAnnotations.ts
@@ -29,10 +29,18 @@ const _getAnnotations = async (position: string, assemblyId: string) => {
   const indexPath = resolvedAssemblyId === 'GRCh38' ? INDEX_38_PATH : INDEX_37_PATH;
 
   const nodeFetch = fetch as Fetcher;
-  const tbiIndexed = new TabixIndexedFile({
-    filehandle: new RemoteFile(annotationUrl, { fetch: nodeFetch }),
-    csiFilehandle: new RemoteFile(indexPath, { fetch: nodeFetch }),
-  });
+  let tbiIndexed: TabixIndexedFile;
+  if (resolvedAssemblyId === 'GRCh37') {
+    tbiIndexed = new TabixIndexedFile({
+      filehandle: new RemoteFile(annotationUrl, { fetch: nodeFetch }),
+      csiFilehandle: new RemoteFile(indexPath, { fetch: nodeFetch }),
+    });
+  } else {
+    tbiIndexed = new TabixIndexedFile({
+      filehandle: new RemoteFile(annotationUrl, { fetch: nodeFetch }),
+      tbiFilehandle: new RemoteFile(indexPath, { fetch: nodeFetch }),
+    });
+  }
 
   const { chromosome, start, end } = resolveChromosome(position);
 

--- a/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
@@ -11,14 +11,14 @@ const createTmpFile = async () => {
   return path.join(dir, filename);
 };
 
-// Get all the start positions of lifted variants.
+// Get start positions of lifted variants.
 const parseBedStart = (bed: String) =>
   bed
     .split('\n')
     .filter(l => !!l && !l.startsWith('#'))
     .map(v => v.split('\t')[1]);
 
-// Get all the end positions of lifted variants.
+// Get end positions of lifted variants.
 const parseBedEnd = (bed: String) =>
   bed
     .split('\n')

--- a/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
@@ -1,0 +1,93 @@
+import { AssemblyId, VariantQueryDataResult } from '../../../types';
+import resolveAssembly from '../utils/resolveAssembly';
+const fs = require('fs/promises');
+const tmpdir = require('os').tmpdir;
+const path = require('path');
+const promiseExec = require('util').promisify(require('child_process').exec);
+
+const createTmpFile = async () => {
+  const filename = Math.random().toString(36).slice(2);
+  const dir = await fs.mkdtemp(path.join(tmpdir(), 'liftover-'));
+  return path.join(dir, filename);
+};
+
+// Get all the start positions of lifted variants.
+const parseBedStart = (bed: String) =>
+  bed
+    .split('\n')
+    .filter(l => !!l && !l.startsWith('#'))
+    .map(v => v.split('\t')[1]);
+
+// Get all the end positions of lifted variants.
+const parseBedEnd = (bed: String) =>
+  bed
+    .split('\n')
+    .filter(l => !!l && !l.startsWith('#'))
+    .map(v => v.split('\t')[2]);
+
+const liftover = async (
+  dataForAnnotation: VariantQueryDataResult[],
+  dataForLiftover: VariantQueryDataResult[],
+  assemblyIdInput: AssemblyId
+) => {
+  // Convert variants from JSON format to BED format.
+  // Note that position format is 1-based and BED format is half-open 0-based: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
+  const bedstring = dataForLiftover
+    .map(v => `chr${v.variant.referenceName}\t${v.variant.start - 1}\t${v.variant.end}`)
+    .join('\n');
+  const lifted = await createTmpFile();
+  const unlifted = await createTmpFile();
+  const bedfile = await createTmpFile();
+  await fs.writeFile(bedfile, bedstring);
+
+  let chain: string;
+  if (assemblyIdInput === 'GRCh37') {
+    chain = '/home/node/hg38ToHg19.over.chain';
+  } else {
+    chain = '/home/node/hg19ToHg38.over.chain';
+  }
+  await promiseExec(`liftOver ${bedfile} ${chain} ${lifted} ${unlifted}`);
+  const _liftedVars = await fs.readFile(lifted);
+  const _unliftedVars = await fs.readFile(unlifted);
+  const liftedVars = parseBedStart(_liftedVars.toString());
+  const unliftedVars = parseBedStart(_unliftedVars.toString());
+  const liftedVarsEnd = parseBedEnd(_liftedVars.toString());
+
+  const unliftedMap: { [key: string]: boolean } = unliftedVars.reduce(
+    (acc, curr) => ({ ...acc, [curr]: true }),
+    {}
+  );
+  const unliftedVariants: VariantQueryDataResult[] = [];
+
+  // Merge lifted variants with dataForAnnotation. Filter unmapped variants.
+  dataForLiftover.forEach((v, i) => {
+    if (unliftedMap[(v.variant.start - 1).toString()]) {
+      v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
+      v.variant.assemblyIdCurrent = v.variant.assemblyId;
+      unliftedVariants.push(v);
+    } else {
+      v.variant.start = Number(liftedVars[i]) + 1; // Convert from BED format to position format.
+      v.variant.end = Number(liftedVarsEnd[i]);
+      v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
+      v.variant.assemblyIdCurrent = assemblyIdInput;
+      dataForAnnotation.push(v);
+    }
+  });
+
+  // Compute the annotation position for the variants that are in user's requested assembly.
+  let geneStart = Infinity;
+  let geneEnd = 0;
+  dataForAnnotation.forEach(result => {
+    if (result.variant.start < geneStart) {
+      geneStart = result.variant.start;
+    }
+    if (result.variant.end > geneEnd) {
+      geneEnd = result.variant.end;
+    }
+  });
+  const annotationPosition = `${dataForAnnotation[0].variant.referenceName}:${geneStart}-${geneEnd}`;
+
+  return { dataForAnnotation, unliftedVariants, annotationPosition };
+};
+
+export default liftover;

--- a/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
@@ -2,7 +2,6 @@ import { promises } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
 import { AssemblyId, VariantQueryDataResult } from '../../../types';
-import resolveAssembly from '../utils/resolveAssembly';
 const exec = require('util').promisify(require('child_process').exec);
 
 const createTmpFile = async () => {
@@ -61,13 +60,11 @@ const liftover = async (
   // Merge lifted variants with dataForAnnotation. Filter unmapped variants.
   dataForLiftover.forEach((v, i) => {
     if (unliftedMap[(v.variant.start - 1).toString()]) {
-      v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
       v.variant.assemblyIdCurrent = v.variant.assemblyId;
       unliftedVariants.push(v);
     } else {
       v.variant.start = Number(liftedVars[i]) + 1; // Convert from BED format to position format.
       v.variant.end = Number(liftedVarsEnd[i]);
-      v.variant.assemblyId = resolveAssembly(v.variant.assemblyId);
       v.variant.assemblyIdCurrent = assemblyIdInput;
       dataForAnnotation.push(v);
     }

--- a/server/src/typeDefs.ts
+++ b/server/src/typeDefs.ts
@@ -38,6 +38,7 @@ export default gql`
   type VariantResponseFields {
     alt: String!
     assemblyId: String!
+    assemblyIdCurrent: String!
     callsets: [CallSet]
     end: Int!
     info: VariantResponseInfoFields

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -33,6 +33,7 @@ export type AssemblyId = 'gnomAD_GRCh37' | '38' | 'GRCh37' | 'GRCh38' | '37' | '
 export interface VariantResponseFields {
   alt: string;
   assemblyId: AssemblyId;
+  assemblyIdCurrent?: AssemblyId;
   callsets: CallSet[];
   end: number;
   info?: VariantResponseInfoFields;


### PR DESCRIPTION
!!! Changes in Docker files are merged from `develop`, `docker-compose up -d --build` is necessary. 

liftOver
-  liftOver is implemented for both conversions `GRCh37` -> `GRCh38` and `GRCh38` -> `GRCh37`.
- CADD annotations for GRCh38 are added. gnomAD annotations for GRCh38 are not added and will be added later when it's loaded in Minio. 
- Unmapped variants if there are any are displayed, they are not annotated with CADD nor gnomAD. 

Frontend: 
- `assemblyIdCurrent` is added to GraphQL queries in order for the frontend to know the current assembly of a row of data. 
- Two columns `Current Assembly` and `Original Assembly` are added to the frontend. 