### PR TITLE
Bug: users should be able to search for 2-letter gene name

### DIFF
--- a/react/src/components/GeneSearch.tsx
+++ b/react/src/components/GeneSearch.tsx
@@ -90,7 +90,7 @@ const GeneSearch: React.FC<GeneSearchProps> = ({ assembly, geneName, onChange, o
                 setOptions([]);
             }
         }
-        if (geneName.length > 2 && !options.map(o => o.value.name).includes(geneName)) {
+        if (geneName.length > 0 && !options.map(o => o.value.name).includes(geneName)) {
             debouncedAutocompleteFetch({ variables: { q: geneName.toLowerCase() } });
         }
     }, [debouncedAutocompleteFetch, geneName, options]);

--- a/react/src/pages/VariantQueryPage.tsx
+++ b/react/src/pages/VariantQueryPage.tsx
@@ -36,7 +36,7 @@ const queryOptionsFormValidator: Validator<QueryOptionsFormState> = {
         required: state => !state.gene.value,
         rules: [
             {
-                valid: (state: FormState<QueryOptionsFormState>) => state.gene.value.length > 3,
+                valid: (state: FormState<QueryOptionsFormState>) => state.gene.value.length > 0,
                 error: 'Too few characters.',
             },
         ],


### PR DESCRIPTION
I changed a condition so users can query for 2-letter gene names.