### PR TITLE
Filter CADD annotation based on consScore

### DIFF
--- a/server/src/resolvers/getVariantsResolver/utils/annotateCadd.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/annotateCadd.ts
@@ -6,7 +6,18 @@ const annotate = (
 ): VariantQueryDataResult[] => {
   const annotationKeys: Record<string, CaddAnnotation> = {};
 
-  annotationResponse.forEach(a => (annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] = a));
+  /** Choose the variant annotation with the highest consScore to prioritize annotation of the most deleterious transcript. 
+  All consequence terms in CADD annotations can be found at https://cadd.gs.washington.edu/static/ReleaseNotes_CADD_v1.3.pdf 
+  For reference, the order of severity of the consequences can be found at https://grch37.ensembl.org/info/genome/variation/prediction/predicted_data.html 
+  */
+  annotationResponse.forEach(a => {
+    if (
+      !annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] ||
+      a.consScore > annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`].consScore
+    ) {
+      annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] = a;
+    }
+  });
 
   queryResponse.forEach(response => {
     const key = `${response.variant.alt}-${response.variant.referenceName.replace(/chr/i, '')}-${

--- a/server/src/resolvers/getVariantsResolver/utils/annotateCadd.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/annotateCadd.ts
@@ -11,10 +11,9 @@ const annotate = (
   For reference, the order of severity of the consequences can be found at https://grch37.ensembl.org/info/genome/variation/prediction/predicted_data.html 
   */
   annotationResponse.forEach(a => {
-    if (
-      !annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] ||
-      a.consScore > annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`].consScore
-    ) {
+    const annotation = annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`];
+
+    if (!annotation || a.consScore > annotation.consScore) {
       annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] = a;
     }
   });

--- a/server/src/resolvers/getVariantsResolver/utils/fetchCaddAnnotations.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/fetchCaddAnnotations.ts
@@ -80,6 +80,7 @@ const _formatAnnotations = (annotations: string[]) => {
     ['ref', 2],
     ['alt', 3],
     ['consequence', 7],
+    ['consScore', 8],
     ['aaRef', 16],
     ['aaAlt', 17],
     ['transcript', 19],

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -178,6 +178,7 @@ export interface CaddAnnotation extends VariantCoordinate {
   aaRef: string;
   cdna: string;
   consequence: string;
+  consScore: number;
   transcript: string;
 }
 


### PR DESCRIPTION
- Prioritize annotation of the most deleteriousness transcript by using the CADD variant annotation with the highest consScore. If multiple variant annotations have the same consScore, the first encountered variant annotation is reported. 
- The correctness of annotation filtering still needs to be verified. This PR is meant to bring the changes to the staging instance such that Magda and Matt could also see the transcript on OSMP after filtering and verify on their end whether the transcripts on OSMP correspond to the transcripts on G4RD phenotips. 