### PR TITLE
React: Cache previously selected visible columns 

### DIFF
--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 import { BsFillEyeFill, BsFillEyeSlashFill } from 'react-icons/bs';
 import { ColumnInstance, HeaderGroup, UseTableInstanceProps } from 'react-table';
@@ -9,6 +9,7 @@ interface ColumnVisibilityModalProps<T extends object>
     extends Pick<UseTableInstanceProps<T>, 'toggleHideColumn'> {
     headerGroups: HeaderGroup<T>[];
     allColumns: ColumnInstance<T>[];
+    visibleColumns: ColumnInstance<T>[];
     setColumnOrder: (update: string[] | ((columnOrder: string[]) => string[])) => void;
     cached: Record<string, boolean>;
     setCached: (value: Record<string, boolean>) => void;
@@ -20,16 +21,26 @@ export default function ColumnVisibilityModal<T extends {}>({
     cached,
     setCached,
     allColumns,
+    visibleColumns,
     setColumnOrder,
 }: ColumnVisibilityModalProps<T>) {
     const [showModal, setShowModal] = useState<boolean>(false);
     const [order, setOrder] = useState<ColumnInstance<T>[]>([]);
     // Cache a column's latest "check" status independent of the column's group status. Does not contain columns with type "empty".
-    const [cachedVisibility, setCachedVisibility] = useState(cached);
+    const [cachedVisibility, setCachedVisibility] = useState<Record<string, boolean>>({});
+    useEffect(() => {
+        setCachedVisibility(cached);
+    }, [cached]);
+
     // State to represent the current "check" status.
-    const [checkedColumns, setCheckedColumns] = useState(
-        Object.fromEntries(allColumns.filter(c => c.type !== 'fixed').map(c => [c.id, c.isVisible]))
-    );
+    const [checkedColumns, setCheckedColumns] = useState<Record<string, boolean>>({});
+    useEffect(() => {
+        setCheckedColumns(
+            Object.fromEntries(
+                allColumns.filter(c => c.type !== 'fixed').map(c => [c.id, c.isVisible])
+            )
+        );
+    }, [allColumns, visibleColumns]);
 
     const groupMapping: Record<string, string> = {
         Variant: 'emptyCore',

--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -1,6 +1,9 @@
+import { isGroup } from '@storybook/api';
+import { check } from 'prettier';
 import { useState } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd';
 import { BsFillEyeFill, BsFillEyeSlashFill } from 'react-icons/bs';
+import { MdOutlineTapAndPlay } from 'react-icons/md';
 import { ColumnInstance, HeaderGroup, UseTableInstanceProps } from 'react-table';
 import { camelize } from '../../utils';
 import { Button, Checkbox, DragHandle, Flex, InlineFlex, Modal } from '../index';
@@ -9,20 +12,39 @@ import { IconPadder } from './Table.styles';
 interface ColumnVisibilityModalProps<T extends object>
     extends Pick<UseTableInstanceProps<T>, 'toggleHideColumn'> {
     headerGroups: HeaderGroup<T>[];
-    toggleGroupVisibility: (g: HeaderGroup<T>) => void;
     allColumns: ColumnInstance<T>[];
     setColumnOrder: (update: string[] | ((columnOrder: string[]) => string[])) => void;
+    cached: Record<string, boolean>;
+    setCached: (value: Record<string, boolean>) => void;
 }
 
 export default function ColumnVisibilityModal<T extends {}>({
     headerGroups,
-    toggleGroupVisibility,
     toggleHideColumn,
+    cached,
+    setCached,
     allColumns,
     setColumnOrder,
 }: ColumnVisibilityModalProps<T>) {
+    const columns = allColumns.filter(c => c.type !== 'fixed');
     const [showModal, setShowModal] = useState<boolean>(false);
     const [order, setOrder] = useState<ColumnInstance<T>[]>([]);
+    const [cachedVisibility, setCachedVisibility] = useState(cached); // Does not contain empty columns
+    const [checkedColumns, setCheckedColumns] = useState(
+        // Contains empty columns
+        Object.fromEntries(columns.map(c => [c.id, c.isVisible]))
+    );
+    const isGroupExpanded = (header: string | undefined) => {
+        if (!header) {
+            return false;
+        } else if (header === 'Variant') {
+            return !checkedColumns['emptyCore'];
+        } else if (header === 'Variant Details') {
+            return !checkedColumns['emptyVariationDetails'];
+        } else {
+            return !checkedColumns['emptyCaseDetails'];
+        }
+    };
     const reorder = (prevPos: number, newPos: number): ColumnInstance<T>[] => {
         const result: ColumnInstance<T>[] = order;
         const [removed] = result.splice(prevPos, 1);
@@ -36,6 +58,100 @@ export default function ColumnVisibilityModal<T extends {}>({
         }
         const columnOrder = reorder(source.index, destination.index);
         setOrder(columnOrder);
+    };
+
+    const groupClick = (g: HeaderGroup<T>) => {
+        // User makes a group invisible
+        const checkedColumnsCopy = Object.assign({}, checkedColumns);
+        if (isGroupExpanded(g.Header as string)) {
+            // All column checkboxes are turned off, empty columns are turned on
+            g.columns
+                ?.filter(c => c.type !== 'fixed')
+                .map(column =>
+                    column.type !== 'empty'
+                        ? (checkedColumnsCopy[column.id] = false)
+                        : (checkedColumnsCopy[column.id] = true)
+                );
+        }
+        // User makes a group visible
+        else {
+            const cacheColumns = g.columns?.filter(
+                c => c.type !== 'fixed' && cachedVisibility[c.id] === true
+            );
+            // If some columns in this group in the cache are visible
+            if (cacheColumns && cacheColumns.length > 0) {
+                g.columns
+                    ?.filter(c => c.type !== 'fixed')
+                    .map(c =>
+                        c.type !== 'empty' && cachedVisibility[c.id]
+                            ? (checkedColumnsCopy[c.id] = true)
+                            : (checkedColumnsCopy[c.id] = false)
+                    );
+            } else {
+                // Else by default make all columns visible
+                g.columns
+                    ?.filter(c => c.type !== 'fixed')
+                    .map(c =>
+                        c.type !== 'empty'
+                            ? (checkedColumnsCopy[c.id] = true)
+                            : (checkedColumnsCopy[c.id] = false)
+                    );
+            }
+        }
+        setCheckedColumns(checkedColumnsCopy);
+    };
+
+    const columnClick = (c: ColumnInstance<T>) => {
+        const checkedColumnsCopy = Object.assign({}, checkedColumns);
+        const cachedVisibilityCopy = Object.assign({}, cachedVisibility);
+        // If user checks a checkbox, update checkedColumns state and cachedVisibility
+        if (!checkedColumnsCopy[c.id]) {
+            checkedColumnsCopy[c.id] = true;
+            cachedVisibilityCopy[c.id] = true;
+            headerGroups[0].headers.forEach(header => {
+                if (
+                    header.columns?.find(column => column.id === c.id) &&
+                    !isGroupExpanded(header.Header as string)
+                ) {
+                    if ((header.Header as string) === 'Variant') {
+                        checkedColumnsCopy['emptyCore'] = false;
+                    } else if ((header.Header as string) === 'Variant Details') {
+                        checkedColumnsCopy['emptyVariationDetails'] = false;
+                    } else {
+                        checkedColumnsCopy['emptyCaseDetails'] = false;
+                    }
+                }
+            });
+        } else {
+            // If user unchecks a checkbox, update checkedColumns state and cachedVisibility
+            checkedColumnsCopy[c.id] = false;
+            cachedVisibilityCopy[c.id] = false;
+            headerGroups[0].headers.forEach(header => {
+                if (
+                    isGroupExpanded(header.Header as string) &&
+                    header.columns?.filter(column => checkedColumnsCopy[column.id]) &&
+                    header.columns?.filter(column => checkedColumnsCopy[column.id]).length === 0
+                ) {
+                    if ((header.Header as string) === 'Variant') {
+                        checkedColumnsCopy['emptyCore'] = true;
+                    } else if ((header.Header as string) === 'Variant Details') {
+                        checkedColumnsCopy['emptyVariationDetails'] = true;
+                    } else {
+                        checkedColumnsCopy['emptyCaseDetails'] = true;
+                    }
+                }
+            });
+        }
+        setCachedVisibility(cachedVisibilityCopy);
+        setCheckedColumns(checkedColumnsCopy);
+    };
+
+    const renderTable = (
+        cachedVisibility: Record<string, boolean>,
+        checkedColumns: Record<string, boolean>
+    ) => {
+        setCached(cachedVisibility);
+        allColumns.map(c => c.type !== 'fixed' && toggleHideColumn(c.id, !checkedColumns[c.id]));
     };
 
     return (
@@ -57,6 +173,7 @@ export default function ColumnVisibilityModal<T extends {}>({
                 footer="Apply"
                 onClick={() => {
                     setColumnOrder(order.map(o => o.id));
+                    renderTable(cachedVisibility, checkedColumns);
                     setShowModal(false);
                 }}
                 helperText="Please check or uncheck the boxes next to each column to toggle the columns' visibility. To reorder the columns, please drag the columns to their desired position. Note that only columns within the same group can be reordered."
@@ -71,8 +188,10 @@ export default function ColumnVisibilityModal<T extends {}>({
                                 >
                                     <Checkbox
                                         label={g.Header as string}
-                                        checked={g.isVisible}
-                                        onClick={() => toggleGroupVisibility(g)}
+                                        checked={isGroupExpanded(g.Header as string)}
+                                        onClick={() => {
+                                            groupClick(g);
+                                        }}
                                     />
                                     {order.map(
                                         (c, id) =>
@@ -83,7 +202,9 @@ export default function ColumnVisibilityModal<T extends {}>({
                                                     key={c.id}
                                                     draggableId={c.id}
                                                     index={id}
-                                                    isDragDisabled={c.isVisible ? false : true}
+                                                    isDragDisabled={
+                                                        checkedColumns[c.id] ? false : true
+                                                    }
                                                 >
                                                     {(provided, snapshot) => (
                                                         <Flex
@@ -101,36 +222,15 @@ export default function ColumnVisibilityModal<T extends {}>({
                                                             >
                                                                 <Checkbox
                                                                     label={c.Header as string}
-                                                                    checked={c.isVisible}
+                                                                    checked={checkedColumns[c.id]}
                                                                     onClick={() => {
-                                                                        if (
-                                                                            c.parent &&
-                                                                            g.columns?.filter(
-                                                                                c => c.isVisible
-                                                                            ).length === 1
-                                                                        ) {
-                                                                            toggleHideColumn(
-                                                                                c.id,
-                                                                                c.isVisible
-                                                                            );
-                                                                            toggleHideColumn(
-                                                                                camelize(
-                                                                                    `empty ${c.parent.id}`
-                                                                                ),
-                                                                                !c.isVisible
-                                                                            );
-                                                                        } else {
-                                                                            toggleHideColumn(
-                                                                                c.id,
-                                                                                c.isVisible
-                                                                            );
-                                                                        }
+                                                                        columnClick(c);
                                                                     }}
                                                                 />
                                                             </div>
 
                                                             <DragHandle
-                                                                isVisible={c.isVisible}
+                                                                isVisible={checkedColumns[c.id]}
                                                                 dragHandleProps={
                                                                     provided.dragHandleProps
                                                                 }

--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -55,11 +55,11 @@ export default function ColumnVisibilityModal<T extends {}>({
 
     // Find a column's group: "Variant", "Variant Details" or "Case Details".
     const columnToGroup = (columnId: string) => {
-        let group = headerGroups[0].headers[0];
-        headerGroups[0].headers.forEach(header => {
-            if (header.columns?.find(c => c.id === columnId)) group = header;
-        });
-        return group;
+        for (let i = 0; i < headerGroups[0].headers.length; i++) {
+            if (headerGroups[0].headers[i].columns?.find(c => c.id === columnId)) {
+                return headerGroups[0].headers[i];
+            }
+        }
     };
 
     const reorder = (prevPos: number, newPos: number): ColumnInstance<T>[] => {
@@ -107,7 +107,7 @@ export default function ColumnVisibilityModal<T extends {}>({
     const onColumnClick = (c: ColumnInstance<T>) => {
         const checkedColumnsCopy = Object.assign({}, checkedColumns);
         const cachedVisibilityCopy = Object.assign({}, cachedVisibility);
-        const group = columnToGroup(c.id);
+        const group = columnToGroup(c.id)!;
         checkedColumnsCopy[c.id] = !checkedColumns[c.id];
         cachedVisibilityCopy[c.id] = !checkedColumns[c.id];
         // If user checks a column and none of the other columns in the group were visible, check the group.

--- a/react/src/components/Table/ColumnVisibilityModal.tsx
+++ b/react/src/components/Table/ColumnVisibilityModal.tsx
@@ -109,10 +109,10 @@ export default function ColumnVisibilityModal<T extends {}>({
         const cachedVisibilityCopy = Object.assign({}, cachedVisibility);
         const group = columnToGroup(c.id)!;
         checkedColumnsCopy[c.id] = !checkedColumns[c.id];
-        cachedVisibilityCopy[c.id] = !checkedColumns[c.id];
-        // If user checks a column and none of the other columns in the group were visible, check the group.
+        // If user checks a column and none of the other columns in the group were visible, check the group, clear the cache for this group.
         if (!checkedColumns[c.id] && !isGroupExpanded(group.Header as string)) {
             checkedColumnsCopy[groupMapping[group.Header as string]] = false;
+            group.columns?.forEach(column => (cachedVisibilityCopy[column.id] = false));
         }
         // If user unchecks a column and none of the other columns in the group were visible, uncheck the group.
         else if (
@@ -122,6 +122,7 @@ export default function ColumnVisibilityModal<T extends {}>({
         ) {
             checkedColumnsCopy[groupMapping[group.Header as string]] = true;
         }
+        cachedVisibilityCopy[c.id] = !checkedColumns[c.id];
         setCachedVisibility(cachedVisibilityCopy);
         setCheckedColumns(checkedColumnsCopy);
     };

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { CgArrowsMergeAltH, CgArrowsShrinkH } from 'react-icons/cg';
 import { RiInformationFill } from 'react-icons/ri';
@@ -487,8 +487,17 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
 
     const { filters, globalFilter } = state;
 
-    const toggleGroupVisibility = (g: HeaderGroup<ResultTableColumns>) =>
+    const [cachedVisibility, setCachedVisibility] = useState(
+        Object.fromEntries(
+            allColumns
+                .filter(c => c.type !== 'fixed' && c.type !== 'empty')
+                .map(column => [column.id, column.isVisible])
+        )
+    );
+
+    const toggleGroupVisibility = (g: HeaderGroup<ResultTableColumns>) => {
         g.columns?.map(c => c.type !== 'fixed' && toggleHideColumn(c.id, c.isVisible));
+    };
 
     var currColour = 'white';
 
@@ -517,8 +526,9 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                 <InlineFlex>
                     <ColumnVisibilityModal
                         headerGroups={headerGroups}
-                        toggleGroupVisibility={toggleGroupVisibility}
                         toggleHideColumn={toggleHideColumn}
+                        cached={cachedVisibility}
+                        setCached={setCachedVisibility}
                         allColumns={allColumns}
                         setColumnOrder={setColumnOrder}
                     />

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -496,7 +496,28 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
     );
 
     const toggleGroupVisibility = (g: HeaderGroup<ResultTableColumns>) => {
-        g.columns?.map(c => c.type !== 'fixed' && toggleHideColumn(c.id, c.isVisible));
+        const columnsInGroup = g.columns?.filter(c => c.type !== 'fixed');
+        const cacheColumns = columnsInGroup?.filter(c => cachedVisibility[c.id] === true);
+        if (!isHeaderExpanded(g)) {
+            if (cacheColumns && cacheColumns.length > 0) {
+                // If some cols in the group are cached, only make these columns visible.
+                columnsInGroup?.forEach(c =>
+                    c.type === 'empty'
+                        ? toggleHideColumn(c.id, true)
+                        : toggleHideColumn(c.id, !cachedVisibility[c.id])
+                );
+            } else {
+                columnsInGroup?.forEach(c =>
+                    c.type === 'empty'
+                        ? toggleHideColumn(c.id, true)
+                        : toggleHideColumn(c.id, false)
+                );
+            }
+        } else {
+            columnsInGroup?.forEach(c =>
+                c.type === 'empty' ? toggleHideColumn(c.id, false) : toggleHideColumn(c.id, true)
+            );
+        }
     };
 
     var currColour = 'white';
@@ -530,6 +551,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         cached={cachedVisibility}
                         setCached={setCachedVisibility}
                         allColumns={allColumns}
+                        visibleColumns={visibleColumns}
                         setColumnOrder={setColumnOrder}
                     />
                     <DownloadModal rows={rows} visibleColumns={visibleColumns} />

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -487,7 +487,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
 
     const { filters, globalFilter } = state;
 
-    const [cachedVisibility, setCachedVisibility] = useState(
+    const [cacheTable, setCacheTable] = useState(
         Object.fromEntries(
             allColumns
                 .filter(c => c.type !== 'fixed' && c.type !== 'empty')
@@ -497,8 +497,8 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
 
     const toggleGroupVisibility = (g: HeaderGroup<ResultTableColumns>) => {
         const columnsInGroup = g.columns?.filter(c => c.type !== 'fixed');
-        const cacheColumns = columnsInGroup?.filter(c => cachedVisibility[c.id] === true);
-        const cachedVisibilityCopy = Object.assign({}, cachedVisibility);
+        const cacheColumns = columnsInGroup?.filter(c => cacheTable[c.id] === true);
+        const cachedVisibilityCopy = Object.assign({}, cacheTable);
 
         //User expands a group
         if (!isHeaderExpanded(g)) {
@@ -507,7 +507,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                 columnsInGroup?.forEach(c =>
                     c.type === 'empty'
                         ? toggleHideColumn(c.id, true)
-                        : toggleHideColumn(c.id, !cachedVisibility[c.id])
+                        : toggleHideColumn(c.id, !cacheTable[c.id])
                 );
             } else {
                 // Display all the columns in the group and update the cache.
@@ -519,7 +519,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         cachedVisibilityCopy[c.id] = true;
                     }
                 });
-                setCachedVisibility(cachedVisibilityCopy);
+                setCacheTable(cachedVisibilityCopy);
             }
         }
         // User collapses a group
@@ -556,8 +556,8 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                     <ColumnVisibilityModal
                         headerGroups={headerGroups}
                         toggleHideColumn={toggleHideColumn}
-                        cached={cachedVisibility}
-                        setCached={setCachedVisibility}
+                        cached={cacheTable}
+                        setCached={setCacheTable}
                         allColumns={allColumns}
                         visibleColumns={visibleColumns}
                         setColumnOrder={setColumnOrder}

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -498,6 +498,9 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
     const toggleGroupVisibility = (g: HeaderGroup<ResultTableColumns>) => {
         const columnsInGroup = g.columns?.filter(c => c.type !== 'fixed');
         const cacheColumns = columnsInGroup?.filter(c => cachedVisibility[c.id] === true);
+        const cachedVisibilityCopy = Object.assign({}, cachedVisibility);
+
+        //User expands a group
         if (!isHeaderExpanded(g)) {
             if (cacheColumns && cacheColumns.length > 0) {
                 // If some cols in the group are cached, only make these columns visible.
@@ -507,16 +510,21 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         : toggleHideColumn(c.id, !cachedVisibility[c.id])
                 );
             } else {
-                columnsInGroup?.forEach(c =>
-                    c.type === 'empty'
-                        ? toggleHideColumn(c.id, true)
-                        : toggleHideColumn(c.id, false)
-                );
+                // Display all the columns in the group and update the cache.
+                columnsInGroup?.forEach(c => {
+                    if (c.type === 'empty') {
+                        toggleHideColumn(c.id, true);
+                    } else {
+                        toggleHideColumn(c.id, false);
+                        cachedVisibilityCopy[c.id] = true;
+                    }
+                });
+                setCachedVisibility(cachedVisibilityCopy);
             }
-        } else {
-            columnsInGroup?.forEach(c =>
-                c.type === 'empty' ? toggleHideColumn(c.id, false) : toggleHideColumn(c.id, true)
-            );
+        }
+        // User collapses a group
+        else {
+            columnsInGroup?.forEach(c => toggleHideColumn(c.id, c.type !== 'empty'));
         }
     };
 


### PR DESCRIPTION
- This PR only addresses issues within a gene search. If a second gene search is performed, the default visible columns is set to be all the columns in the group "Variant". However, if we want to conserve visible columns between gene searches, this issue will be addressed in another PR.  

- In the result table, collapsing a group will make all columns in the group invisible. Expanding a group will show only previously visible groups. 
- In the "Column VIsibility" pop-up, unchecking a group will uncheck all the columns in the group. Checking a group will only show cached visible columns ( in the case that there are no cached visible columns, all the columns in the group will be shown). Closing the "Column Visibility" pop-up will not save the changes made in the pop-up. 
- In summary, there is a cache `cacheTable` for the result table and a cache `cacheVisibility` for the "Column Visibility" pop-up. Every time user opens the "Column Visibility" modal, `cacheVisibility` is initialized to be equal to `cacheTable`. Every time user clicks `apply` in the modal, `cacheTable` is updated to be equal to `cacheVisibility`. 
