### PR TITLE
Replace the "gnomad_exome_AF" column with the "gnomAD_AF" column

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -178,9 +178,7 @@ jobs:
           KEYCLOAK_DB_USER: ${{ secrets.KEYCLOAK_DB_USER }}
           KEYCLOAK_DB_PASSWORD: ${{ secrets.KEYCLOAK_DB_PASSWORD }}
           # Mongo
-          MONGO_INITDB_ROOT_USERNAME: ${{ secrets.MONGO_INITDB_ROOT_USERNAME }}
-          MONGO_INITDB_DATABASE: ${{ secrets.MONGO_INITDB_DATABASE }}
-          MONGO_INITDB_ROOT_PASSWORD: ${{ secrets.MONGO_INITDB_ROOT_PASSWORD }}
+          MONGO_CONNECTION_STRING: ${{ secrets.MONGO_CONNECTION_STRING }}
         run: |
           eval "${{ steps.configure.outputs.ssh-agent-eval }}"
           docker-compose pull

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -24,7 +24,7 @@ services:
       KEYCLOAK_AUTH_URL:
       KEYCLOAK_CLIENT_ID:
       KEYCLOAK_REALM:
-      MONGO_CONNECTION_STRING: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongo/${MONGO_INITDB_DATABASE}?authSource=admin
+      MONGO_CONNECTION_STRING:
       TEST_NODE_URL: http://test-node:3000/data
     ports:
       - 3000:3000
@@ -66,14 +66,4 @@ services:
       KEYCLOAK_FRONTEND_URL: "https://keycloak.ccmdev.ca/auth"
     ports:
       - 8080:8080
-    <<: *common
-
-  mongo:
-    image: mongo:latest
-    environment:
-      MONGO_INITDB_ROOT_USERNAME:
-      MONGO_INITDB_DATABASE:
-      MONGO_INITDB_ROOT_PASSWORD:
-    volumes:
-      - ${PROJECT_ROOT:-.}/mongo_data:/data/db
     <<: *common

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -236,8 +236,8 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                     {
                         accessor: 'af',
                         id: 'af',
-                        Header: 'gnomad_exome_AF',
-                        width: getColumnWidth('gnomad_exome_AF', true),
+                        Header: 'gnomAD_AF',
+                        width: getColumnWidth('gnomAD_AF', true),
                         filter: 'between',
                     },
                     /* { accessor: 'gnomadHet', id: 'gnomadHet', Header: 'gnomadHet', width: 105 }, */

--- a/react/src/constants/headers.ts
+++ b/react/src/constants/headers.ts
@@ -4,12 +4,10 @@
 
 const HEADERS: { [x: string]: string } = {
     source: 'The institution where the data comes from',
-    af:
-        'Allele frequency from gnomAD, defined as the highest value between the gnomAD exome allele frequency and the gnomAD genome allele frequency.',
+    af: 'Allele frequency from gnomAD, defined as the highest value between the gnomAD exome allele frequency and the gnomAD genome allele frequency.',
     ethnicity:
         'Ethnic background of the individual. Value from NCIT Race ontology (NCIT:C17049), e.g. NCIT:C126531 (Latin American).',
-    sex:
-        'Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993) ontology: UNKNOWN (not assessed or not available) (NCIT:C17998), FEMALE (NCIT:C46113), MALE, (NCIT:C46112) or OTHER SEX (NCIT:C45908).',
+    sex: 'Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993) ontology: UNKNOWN (not assessed or not available) (NCIT:C17998), FEMALE (NCIT:C46113), MALE, (NCIT:C46112) or OTHER SEX (NCIT:C45908).',
     geographicOrigin:
         "Individual's country or region of origin (birthplace or residence place regardless of ethnic origin). Value from GAZ Geographic Location ontology (GAZ:00000448), e.g. GAZ:00002459 (United States of America).",
     diseases:

--- a/react/src/constants/headers.ts
+++ b/react/src/constants/headers.ts
@@ -4,7 +4,7 @@
 
 const HEADERS: { [x: string]: string } = {
     source: 'The institution where the data comes from',
-    af: 'Allele frequency from gnomAD, defined as the highest value between the gnomAD exome allele frequency and the gnomAD genome allele frequency.',
+    af: 'Allele frequency from gnomAD, defined as the greater value between the exome allele frequency and the genome allele frequency.',
     ethnicity:
         'Ethnic background of the individual. Value from NCIT Race ontology (NCIT:C17049), e.g. NCIT:C126531 (Latin American).',
     sex: 'Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993) ontology: UNKNOWN (not assessed or not available) (NCIT:C17998), FEMALE (NCIT:C46113), MALE, (NCIT:C46112) or OTHER SEX (NCIT:C45908).',

--- a/react/src/constants/headers.ts
+++ b/react/src/constants/headers.ts
@@ -4,10 +4,12 @@
 
 const HEADERS: { [x: string]: string } = {
     source: 'The institution where the data comes from',
-    af: 'Allele frequency of exomes from gnomAD',
+    af:
+        'Allele frequency from gnomAD, defined as the highest value between the gnomAD exome allele frequency and the gnomAD genome allele frequency.',
     ethnicity:
         'Ethnic background of the individual. Value from NCIT Race ontology (NCIT:C17049), e.g. NCIT:C126531 (Latin American).',
-    sex: 'Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993) ontology: UNKNOWN (not assessed or not available) (NCIT:C17998), FEMALE (NCIT:C46113), MALE, (NCIT:C46112) or OTHER SEX (NCIT:C45908).',
+    sex:
+        'Sex of the individual. Value from NCIT General Qualifier (NCIT:C27993) ontology: UNKNOWN (not assessed or not available) (NCIT:C17998), FEMALE (NCIT:C46113), MALE, (NCIT:C46112) or OTHER SEX (NCIT:C45908).',
     geographicOrigin:
         "Individual's country or region of origin (birthplace or residence place regardless of ethnic origin). Value from GAZ Geographic Location ontology (GAZ:00000448), e.g. GAZ:00002459 (United States of America).",
     diseases:

--- a/server/__tests__/utils/annotateGnomad.test.ts
+++ b/server/__tests__/utils/annotateGnomad.test.ts
@@ -1,23 +1,34 @@
 import { annotate } from '../../src/resolvers/getVariantsResolver/utils/annotateGnomad';
-import { GnomadAnnotation, VariantQueryDataResult } from '../../src/types';
+import { GnomadAnnotation, GnomadAnnotations, VariantQueryDataResult } from '../../src/types';
 
 /**
     Confirms that the variant query response is annotated before getting returned to the frontend
 */
 describe('Test whether variants get annotated', () => {
-  const annotations: GnomadAnnotation[] = [
+  const annotation: Omit<GnomadAnnotation, 'af' | 'type'> = {
+    alt: 'T',
+    an: 1,
+    assembly: 'gnomAD_GRCh37',
+    chrom: '1',
+    nhomalt: 1,
+    pos: 123456,
+    ref: 'A',
+  };
+  const exomeAnnotations: GnomadAnnotation[] = [
     {
+      ...annotation,
       af: 1,
-      alt: 'T',
-      an: 1,
-      assembly: 'gnomAD_GRCh37',
-      chrom: '1',
-      nhomalt: 1,
-      pos: 123456,
-      ref: 'A',
       type: 'exome',
     },
   ];
+  const genomeAnnotations: GnomadAnnotation[] = [
+    {
+      ...annotation,
+      af: 2,
+      type: 'genome',
+    },
+  ];
+  const annotations: GnomadAnnotations = { exomeAnnotations, genomeAnnotations };
 
   it('finds the correct coordinates and returns a unique annotation', () => {
     const variants: VariantQueryDataResult[] = [
@@ -43,9 +54,9 @@ describe('Test whether variants get annotated', () => {
     // Check if the corresponding variant has info fields populated
     result.forEach(nodeData =>
       expect(nodeData.variant.info).toEqual({
-        af: annotations[0].af,
-        an: annotations[0].an,
-        gnomadHom: annotations[0].nhomalt,
+        af: Math.max(exomeAnnotations[0].af, genomeAnnotations[0].af),
+        an: exomeAnnotations[0].an,
+        gnomadHom: exomeAnnotations[0].nhomalt,
       })
     );
   });

--- a/server/src/models/GnomadAnnotationModel.ts
+++ b/server/src/models/GnomadAnnotationModel.ts
@@ -54,16 +54,17 @@ gnomandAnnotationSchema.statics.getAnnotations = async function (
   assemblyId: string
 ) {
   const { start, end, coordinates } = ids;
-  const getAnnotationsByType = async (type: AnnotationType) => await this.aggregate([
-    { $match: { type }},
-    { $match: { assembly: assemblyId } },
-    { $match: { pos: { $gte: start, $lte: end } } },
-    {
-      $match: {
-        $or: coordinates,
+  const getAnnotationsByType = async (type: AnnotationType) =>
+    await this.aggregate([
+      { $match: { type } },
+      { $match: { assembly: assemblyId } },
+      { $match: { pos: { $gte: start, $lte: end } } },
+      {
+        $match: {
+          $or: coordinates,
+        },
       },
-    },
-  ]);
+    ]);
   const annotations = {
     exomeAnnotations: [] as GnomadAnnotation[],
     genomeAnnotations: [] as GnomadAnnotation[],
@@ -76,7 +77,7 @@ gnomandAnnotationSchema.statics.getAnnotations = async function (
     console.log(`${annotations.exomeAnnotations.length} exome gnomAD annotation(s) found`);
     console.log(`${annotations.genomeAnnotations.length} genome gnomAD annotation(s) found`);
   }
-  
+
   return annotations;
 };
 

--- a/server/src/resolvers/getVariantsResolver/utils/annotateGnomad.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/annotateGnomad.ts
@@ -34,7 +34,7 @@ export const annotate = (
     }-${r.variant.assemblyId.replace(/\D/g, '')}`;
 
     if (variantKey in exomeAnnotationKeyMap) {
-      /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+      /* eslint-disable @typescript-eslint/no-unused-vars */
       const {
         af: exomeAF,
         alt,
@@ -47,6 +47,7 @@ export const annotate = (
         nhomalt,
         ...rest
       } = exomeAnnotationKeyMap[variantKey];
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       const genomeAF = genomeAnnotationKeyMap?.[variantKey]?.af ?? 0;
 
       r.variant.info = {

--- a/server/src/resolvers/getVariantsResolver/utils/annotateGnomad.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/annotateGnomad.ts
@@ -15,9 +15,10 @@ const annotateGnomad = async (
   return annotate(queryResponse, annotations);
 };
 
-const _mapToAnnotationsKeyMap = (annotations: GnomadAnnotation[]) => Object.fromEntries(
-  annotations.map(a => [`${a.ref}-${a.pos}-${a.chrom}-${a.assembly.replace(/\D/g, '')}`, a])
-);
+const _mapToAnnotationsKeyMap = (annotations: GnomadAnnotation[]) =>
+  Object.fromEntries(
+    annotations.map(a => [`${a.ref}-${a.pos}-${a.chrom}-${a.assembly.replace(/\D/g, '')}`, a])
+  );
 
 export const annotate = (
   queryResponse: VariantQueryDataResult[],
@@ -34,8 +35,18 @@ export const annotate = (
 
     if (variantKey in exomeAnnotationKeyMap) {
       /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-      const { af: exomeAF, alt, assembly, cdna, chrom, ref, pos, type, nhomalt, ...rest } =
-        exomeAnnotationKeyMap[variantKey];
+      const {
+        af: exomeAF,
+        alt,
+        assembly,
+        cdna,
+        chrom,
+        ref,
+        pos,
+        type,
+        nhomalt,
+        ...rest
+      } = exomeAnnotationKeyMap[variantKey];
       const genomeAF = genomeAnnotationKeyMap?.[variantKey]?.af ?? 0;
 
       r.variant.info = {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -202,6 +202,11 @@ export interface GnomadAnnotation extends VariantCoordinate {
   type: string;
 }
 
+export interface GnomadAnnotations {
+  exomeAnnotations: GnomadAnnotation[];
+  genomeAnnotations: GnomadAnnotation[];
+}
+
 export interface ErrorResponse {
   id: string;
   code: number | string;


### PR DESCRIPTION
- Add query for gnomAD GRCh37 genome annotations
- Calculate the gnomAD allele frequency as the highest value between the gnomAD exome allele frequency and the gnomAD genome allele frequency
- Rename the `gnomad_exome_AF` column to `gnomAD_AF`
- Update the header tooltip text for the `gnomAD_AF` column to specify how the gnomAD allele frequency is calculated