### PR TITLE
React: Fix removal of non-unique variants for remote-test node 

### DIFF
--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -644,7 +644,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                                                     justifyContent="center"
                                                                     nowrap
                                                                 >
-                                                                    {/* 
+                                                                    {/*
                                                                         Filter icon for filtering individual columns
                                                                     */}
                                                                     {!column.disableFilters && (
@@ -780,8 +780,8 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                     // Display only one row per variant if Case Details Section is collapsed.
                                     if (
                                         isCaseDetailsCollapsed(headerGroups[0].headers) &&
-                                        uniqueVariantIndices.find(i => i === row?.index) ===
-                                            undefined
+                                        // rows are sorted by uniqueId, so if a row came before it with the same id, then it's not unique
+                                        row?.index !== 0 && row.values['uniqueId'] === page[i-1].values['uniqueId']
                                     ) {
                                         return null;
                                     }


### PR DESCRIPTION
Closes #243 
Table rows are sorted by `uniqueId` after we get the `uniqueVariantIndices` from `prepareData`, meaning that they can fall out-of-sync since the order is not preserved. The change uses only the `uniqueId` of the current and previous rows to determine whether to show the row or not when the Case Details columns are hidden.