### PR TITLE
React: Modify "Affected Status" and "Phenotypes" columns

### DIFF
--- a/react/src/components/Table/PhenotypeViewer.tsx
+++ b/react/src/components/Table/PhenotypeViewer.tsx
@@ -5,14 +5,12 @@ import CellViewer, { ViewerProps } from './CellViewer';
 
 interface PhenotypeViewerProps extends ViewerProps {
     phenotypes: Maybe<PhenotypicFeaturesFields[]>;
-    clinicalStatus: Maybe<String>;
 }
 
 const PhenotypeViewer: React.FC<PhenotypeViewerProps> = ({
     phenotypes,
     rowExpanded,
     toggleRowExpanded,
-    clinicalStatus,
 }) => {
     return (
         <CellViewer<PhenotypicFeaturesFields>
@@ -20,7 +18,6 @@ const PhenotypeViewer: React.FC<PhenotypeViewerProps> = ({
             formatText={phenotype => phenotype.phenotypeLabel || ''}
             itemName="Phenotype"
             items={phenotypes}
-            text={clinicalStatus === 'unaffected' ? 'This patient is clinically normal' : ''}
         />
     );
 };

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -352,7 +352,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         width: getColumnWidth('Diseases', true),
                     },
                     {
-                        accessor: 'diagnosis',
+                        accessor: 'clinicalStatus',
                         filter: 'multiSelect',
                         id: 'affectedStatus',
                         Header: 'Affected Status',
@@ -399,7 +399,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         Cell: ({
                             row: {
                                 isExpanded,
-                                original: { clinicalStatus, phenotypicFeatures },
+                                original: { phenotypicFeatures },
                                 toggleRowExpanded,
                             },
                         }: {
@@ -409,7 +409,6 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                 {...{ toggleRowExpanded }}
                                 phenotypes={phenotypicFeatures}
                                 rowExpanded={isExpanded}
-                                clinicalStatus={clinicalStatus}
                             />
                         ),
                     },
@@ -781,7 +780,8 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                     if (
                                         isCaseDetailsCollapsed(headerGroups[0].headers) &&
                                         // rows are sorted by uniqueId, so if a row came before it with the same id, then it's not unique
-                                        row?.index !== 0 && row.values['uniqueId'] === page[i-1].values['uniqueId']
+                                        row?.index !== 0 &&
+                                        row.values['uniqueId'] === page[i - 1].values['uniqueId']
                                     ) {
                                         return null;
                                     }


### PR DESCRIPTION
According to Magda and Matt's feedback, see [OSMP Gantt chart](https://docs.google.com/spreadsheets/d/1eztLBGeqjYj3IafpPxhZo5mbvz6Xzw0LbP_9_HpxeHA/edit#gid=2130371978)

- For "Affected Status" column, we should display "affected" or "unaffected" according to `clinicalStatus` returned from the Phenotips endpoint. 
- For "Phenotypes" column, we should remove the display of "This patient is clinically normal" and display phenotypes when they exist.  