### PR TITLE
Bug: Fix a bug with the column group divider

### DIFF
--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -518,7 +518,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
         rows,
     } = tableInstance;
 
-    const { filters, globalFilter } = state;
+    const { columnOrder, filters, globalFilter } = state;
 
     const [cacheTable, setCacheTable] = useState(
         Object.fromEntries(
@@ -643,7 +643,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                             return (
                                                 <TH
                                                     key={key}
-                                                    className={isLastHeaderInSet(column) ? 'last-in-set' : ''}
+                                                    className={isLastHeaderInSet(column, columnOrder) ? 'last-in-set' : ''}
                                                     {...restHeaderProps}
                                                 >
                                                     <AnimatePresence initial={false}>
@@ -823,7 +823,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                                 return (
                                                     <td
                                                         key={key}
-                                                        className={isLastCellInSet(cell) ? 'last-in-set' : ''}
+                                                        className={isLastCellInSet(cell, columnOrder) ? 'last-in-set' : ''}
                                                         style={{
                                                             paddingRight: 0,
                                                             paddingLeft: 0,


### PR DESCRIPTION
Fix a bug with the column group divider where it can become misaligned/out of sync if a column is reordered to be the last in its set