### PR TITLE
React Apollo: Use non-subscription approach for remote node error link

### DIFF
--- a/react/src/apollo/client.ts
+++ b/react/src/apollo/client.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, createHttpLink, from, InMemoryCache, useLazyQuery } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
-import { ApolloLink, QueryHookOptions, useQuery } from '@apollo/react-hooks';
+import { ApolloLink, QueryHookOptions, ServerError, useQuery } from '@apollo/react-hooks';
 import { RestLink } from 'apollo-link-rest';
 import ApolloLinkTimeout from 'apollo-link-timeout';
 import { DocumentNode } from 'graphql';
@@ -53,6 +53,12 @@ export const buildLink = (token?: string) => {
         if (networkError) {
             console.error(`[Network error]: ${networkError}`);
             networkError.message = `${networkError.message} (Source: ${sources.join(', ')})`;
+            if ((networkError as ServerError).statusCode === 403) {
+                networkError.message = `${networkError.message} Refreshing...`;
+                setTimeout(() => {
+                    window.location.reload();
+                }, 3_000);
+            }
             dispatch(makeNetworkError(networkError));
         }
 

--- a/react/src/apollo/client.ts
+++ b/react/src/apollo/client.ts
@@ -1,10 +1,4 @@
-import {
-    ApolloClient,
-    createHttpLink,
-    from,
-    InMemoryCache,
-    useLazyQuery,
-} from '@apollo/client';
+import { ApolloClient, createHttpLink, from, InMemoryCache, useLazyQuery } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 import { ApolloLink, QueryHookOptions, useQuery } from '@apollo/react-hooks';
 import { RestLink } from 'apollo-link-rest';
@@ -27,22 +21,20 @@ export const buildLink = (token?: string) => {
     });
 
     const remoteNodeErrorLink = new ApolloLink((operation, forward) => {
-        return forward(operation).map((result) => {
+        return forward(operation).map(result => {
             // https://github.com/apollographql/apollo-link/issues/298
             const errorDispatch = operation.getContext().dispatch;
             // const errorDispatch = result.context!.dispatch;  // Is this more 'correct'?
             if (result.data?.getVariants.errors.length) {
-                result.data?.getVariants.errors.forEach(
-                    (e: VariantQueryResponseError) => {
-                        errorDispatch(makeNodeError(e));
-                    }
-                );
+                result.data?.getVariants.errors.forEach((e: VariantQueryResponseError) => {
+                    errorDispatch(makeNodeError(e));
+                });
             }
             return result;
         });
     });
 
-    const errorLink = onError((errorResponse) => {
+    const errorLink = onError(errorResponse => {
         const { graphQLErrors, networkError, operation, /*response, */ forward } = errorResponse;
         const { dispatch } = operation.getContext();
         const sources = operation.variables.input.sources;

--- a/react/src/apollo/client.ts
+++ b/react/src/apollo/client.ts
@@ -28,6 +28,7 @@ export const buildLink = (token?: string) => {
 
     const remoteNodeErrorLink = new ApolloLink((operation, forward) => {
         return forward(operation).map((result) => {
+            // https://github.com/apollographql/apollo-link/issues/298
             const errorDispatch = operation.getContext().dispatch;
             // const errorDispatch = result.context!.dispatch;  // Is this more 'correct'?
             if (result.data?.getVariants.errors.length) {


### PR DESCRIPTION
Closes #103 ~~(partially)~~

Definitely need someone with more experience with Apollo to validate this.

My understanding of the issue is that previously, `remoteNodeErrorLink` used a subscription (ie. a WebSocket connection) to check for gql errors. This link was suppressing network errors for some reason, causing failed gql requests to hang until the timeout link triggered. I've changed this to a link that does not use subscriptions and it appears to work fine. 

~~I'll create a new issue for redirecting to login on 403.~~ Login redirects should happen automatically, so I will update this PR to include a prompt to refresh the page.