### PR TITLE
React: Remove pagination from table; fix cached results not updating table correctly

### DIFF
--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -15,7 +15,6 @@ import {
     useFilters,
     useFlexLayout,
     useGlobalFilter,
-    usePagination,
     useResizeColumns,
     useSortBy,
     useTable,
@@ -480,7 +479,6 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
             data: tableData,
             filterTypes,
             initialState: {
-                pageSize: tableData.length,
                 sortBy: sortByArray,
                 hiddenColumns: [
                     getChildColumns('case_details'),
@@ -496,8 +494,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
         useFlexLayout,
         useGlobalFilter,
         useSortBy,
-        useExpanded,
-        usePagination
+        useExpanded
     );
 
     const {
@@ -505,7 +502,6 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
         getTableProps,
         getTableBodyProps,
         headerGroups,
-        page,
         state,
         setColumnOrder,
         setFilter,
@@ -801,15 +797,15 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         </THead>
 
                         <tbody {...getTableBodyProps()}>
-                            {page.length > 0 ? (
-                                page.map((row, i) => {
+                            {rows.length > 0 ? (
+                                rows.map((row, i) => {
                                     prepareRow(row);
                                     // Alternate row's background colour.
                                     const { key, ...restRowProps } = row.getRowProps(
                                         i !== 0
                                             ? getRowColour(
                                                   row.values['uniqueId'],
-                                                  page[i - 1].values['uniqueId']
+                                                  rows[i - 1].values['uniqueId']
                                               )
                                             : [{ style: { background: 'white' } }]
                                     );
@@ -818,7 +814,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                         isCaseDetailsCollapsed(headerGroups[0].headers) &&
                                         // rows are sorted by uniqueId, so if a row came before it with the same id, then it's not unique
                                         row?.index !== 0 &&
-                                        row.values['uniqueId'] === page[i - 1]?.values['uniqueId']
+                                        row.values['uniqueId'] === rows[i - 1]?.values['uniqueId']
                                     ) {
                                         return null;
                                     }


### PR DESCRIPTION
Closes #285 

Retrieving search results from cache updates the table correctly, but not the size of the page. Since we only ever display *all* results in the table with no pagination controls, I removed any mention of pagination from the table and opt to read from `tableInstance.rows` instead of `tableInstance.page`.