### PR TITLE
Node: add timeit wrapper functions

### DIFF
--- a/server/src/models/GnomadAnnotationModel.ts
+++ b/server/src/models/GnomadAnnotationModel.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, Model, model } from 'mongoose';
+import logger from '../logger';
 import { GnomadAnnotation } from '../types';
 
 export type GnomadAnnotationId = Pick<GnomadAnnotation, 'alt' | 'chrom' | 'ref' | 'pos'>;
@@ -63,7 +64,7 @@ gnomandAnnotationSchema.statics.getAnnotations = async function (
         },
       },
     ]);
-    console.log(`${annotation.length} gnomad annots found`);
+    logger.debug(`${annotation.length} gnomad annots found`);
     return annotation;
   } else {
     return [];

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -15,6 +15,7 @@ import annotateCadd from './utils/annotateCadd';
 import annotateGnomad from './utils/annotateGnomad';
 import liftover from './utils/liftOver';
 import getG4rdNodeQuery from './adapters/g4rdAdapter';
+import { timeitAsync } from '../../utils/timeit';
 
 const getVariants = async (parent: any, args: QueryInput): Promise<CombinedVariantQueryResponse> =>
   await resolveVariantQuery(args);
@@ -23,107 +24,111 @@ const isVariantQuery = (
   arg: VariantQueryResponse | CADDAnnotationQueryResponse
 ): arg is VariantQueryResponse => arg.source !== 'CADD annotations';
 
-const resolveVariantQuery = async (args: QueryInput): Promise<CombinedVariantQueryResponse> => {
-  const {
-    input: {
-      sources,
-      variant: { assemblyId },
-      gene: { position },
-    },
-  } = args;
+const resolveVariantQuery = timeitAsync('resolveVariantQuery')(
+  async (args: QueryInput): Promise<CombinedVariantQueryResponse> => {
+    const {
+      input: {
+        sources,
+        variant: { assemblyId },
+        gene: { position },
+      },
+    } = args;
 
-  let annotationPosition = position;
+    let annotationPosition = position;
 
-  // fetch data
-  const queries = sources.map(source => buildSourceQuery(source, args));
-  const settledQueries = await Promise.allSettled([...queries]);
+    // fetch data
+    const queries = sources.map(source => buildSourceQuery(source, args));
+    const settledQueries = await Promise.allSettled([...queries]);
 
-  const errors: SourceError[] = [];
-  const combinedResults: VariantQueryDataResult[] = [];
+    const errors: SourceError[] = [];
+    const combinedResults: VariantQueryDataResult[] = [];
 
-  /* inspect variant results and combine if no errors */
-  settledQueries.forEach(response => {
-    if (
-      response.status === 'fulfilled' &&
-      isVariantQuery(response.value) &&
-      !response.value.error
-    ) {
-      combinedResults.push(...response.value.data);
-    } else if (response.status === 'fulfilled' && !!response.value.error) {
-      const message =
-        process.env.NODE_ENV === 'production' && response.value.error.code === 500
-          ? 'Something went wrong!'
-          : response.value.error.message;
+    /* inspect variant results and combine if no errors */
+    settledQueries.forEach(response => {
+      if (
+        response.status === 'fulfilled' &&
+        isVariantQuery(response.value) &&
+        !response.value.error
+      ) {
+        combinedResults.push(...response.value.data);
+      } else if (response.status === 'fulfilled' && !!response.value.error) {
+        const message =
+          process.env.NODE_ENV === 'production' && response.value.error.code === 500
+            ? 'Something went wrong!'
+            : response.value.error.message;
 
-      errors.push({
-        source: response.value.source,
-        error: { ...response.value.error!, message },
-      });
-    } else if (response.status === 'rejected') {
-      logger.error('UNHANDLED REJECTION!');
-      logger.error(response.reason);
-      throw new Error(response.reason);
-    }
-  });
-
-  // filter data that are not in user requested assemblyId
-  const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId);
-  // filter data that are already in user requested assemlbyId
-  let dataForAnnotation = combinedResults.filter(v => {
-    if (v.variant.assemblyId === assemblyId) {
-      v.variant.assemblyIdCurrent = assemblyId;
-      return true;
-    } else return false;
-  });
-  let unliftedVariants: VariantQueryDataResult[] = [];
-
-  // perform liftOver if needed
-  if (dataForLiftover.length) {
-    const liftoverResults = await liftover(dataForAnnotation, dataForLiftover, assemblyId);
-    ({ unliftedVariants, dataForAnnotation, annotationPosition } = liftoverResults);
-  }
-
-  // Cadd annotations for data in user requested assemblyId
-  let data: VariantQueryDataResult[] = dataForAnnotation;
-  const caddAnnotationsPromise = fetchCaddAnnotations(annotationPosition, assemblyId);
-  const settledCadd = (await Promise.allSettled([caddAnnotationsPromise]))[0]; // wait for single promise to settle
-
-  if (
-    settledCadd.status === 'fulfilled' &&
-    !isVariantQuery(settledCadd.value) &&
-    !settledCadd.value.error
-  ) {
-    data = annotateCadd(dataForAnnotation, settledCadd.value.data);
-  } else if (settledCadd.status === 'fulfilled') {
-    errors.push({
-      source: settledCadd.value.source,
-      error: settledCadd.value.error as ErrorResponse,
+        errors.push({
+          source: response.value.source,
+          error: { ...response.value.error!, message },
+        });
+      } else if (response.status === 'rejected') {
+        logger.error('UNHANDLED REJECTION!');
+        logger.error(response.reason);
+        throw new Error(response.reason);
+      }
     });
-  }
 
-  // gnomAD annotations TODO: gnomAD annotations for GRCh38 are not available yet.
-  if (assemblyId === 'GRCh37') {
-    data = await annotateGnomad(data ?? dataForAnnotation);
-  }
+    // filter data that are not in user requested assemblyId
+    const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId);
+    // filter data that are already in user requested assemlbyId
+    let dataForAnnotation = combinedResults.filter(v => {
+      if (v.variant.assemblyId === assemblyId) {
+        v.variant.assemblyIdCurrent = assemblyId;
+        return true;
+      } else return false;
+    });
+    let unliftedVariants: VariantQueryDataResult[] = [];
 
-  // return unmapped variants if there's any
-  if (unliftedVariants.length) {
-    data = data.concat(unliftedVariants);
-  }
-  return { errors, data };
-};
+    // perform liftOver if needed
+    if (dataForLiftover.length) {
+      const liftoverResults = await liftover(dataForAnnotation, dataForLiftover, assemblyId);
+      ({ unliftedVariants, dataForAnnotation, annotationPosition } = liftoverResults);
+    }
 
-const buildSourceQuery = (source: string, args: QueryInput): Promise<VariantQueryResponse> => {
-  switch (source) {
-    case 'local':
-      return getLocalQuery();
-    case 'remote-test':
-      return getRemoteTestNodeQuery(args);
-    case 'g4rd':
-      return getG4rdNodeQuery(args);
-    default:
-      throw new Error(`source ${source} not found!`);
+    // Cadd annotations for data in user requested assemblyId
+    let data: VariantQueryDataResult[] = dataForAnnotation;
+    const caddAnnotationsPromise = fetchCaddAnnotations(annotationPosition, assemblyId);
+    const settledCadd = (await Promise.allSettled([caddAnnotationsPromise]))[0]; // wait for single promise to settle
+
+    if (
+      settledCadd.status === 'fulfilled' &&
+      !isVariantQuery(settledCadd.value) &&
+      !settledCadd.value.error
+    ) {
+      data = annotateCadd(dataForAnnotation, settledCadd.value.data);
+    } else if (settledCadd.status === 'fulfilled') {
+      errors.push({
+        source: settledCadd.value.source,
+        error: settledCadd.value.error as ErrorResponse,
+      });
+    }
+
+    // gnomAD annotations TODO: gnomAD annotations for GRCh38 are not available yet.
+    if (assemblyId === 'GRCh37') {
+      data = await annotateGnomad(data ?? dataForAnnotation);
+    }
+
+    // return unmapped variants if there's any
+    if (unliftedVariants.length) {
+      data = data.concat(unliftedVariants);
+    }
+    return { errors, data };
   }
-};
+);
+
+const buildSourceQuery = timeitAsync('buildSourceQuery')(
+  (source: string, args: QueryInput): Promise<VariantQueryResponse> => {
+    switch (source) {
+      case 'local':
+        return getLocalQuery();
+      case 'remote-test':
+        return getRemoteTestNodeQuery(args);
+      case 'g4rd':
+        return getG4rdNodeQuery(args);
+      default:
+        throw new Error(`source ${source} not found!`);
+    }
+  }
+);
 
 export default getVariants;

--- a/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
+++ b/server/src/resolvers/getVariantsResolver/getVariantsResolver.ts
@@ -68,6 +68,8 @@ const resolveVariantQuery = timeitAsync('resolveVariantQuery')(
       }
     });
 
+    logger.debug(`${combinedResults.length} partipants found from queries`);
+
     // filter data that are not in user requested assemblyId
     const dataForLiftover = combinedResults.filter(v => v.variant.assemblyId !== assemblyId);
     // filter data that are already in user requested assemlbyId

--- a/server/src/resolvers/getVariantsResolver/utils/annotateCadd.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/annotateCadd.ts
@@ -1,52 +1,55 @@
 import { CaddAnnotation, VariantQueryDataResult } from '../../../types';
 import AMINO_ACID_MAPPING from '../../../constants/aminoAcidMapping';
+import { timeit } from '../../../utils/timeit';
 
-const annotate = (
-  queryResponse: VariantQueryDataResult[],
-  annotationResponse: CaddAnnotation[]
-): VariantQueryDataResult[] => {
-  const annotationKeys: Record<string, CaddAnnotation> = {};
+const annotate = timeit('annotateCadd')(
+  (
+    queryResponse: VariantQueryDataResult[],
+    annotationResponse: CaddAnnotation[]
+  ): VariantQueryDataResult[] => {
+    const annotationKeys: Record<string, CaddAnnotation> = {};
 
-  /** Choose the variant annotation with the highest consScore to prioritize annotation of the most deleterious transcript. 
-  All consequence terms in CADD annotations can be found at https://cadd.gs.washington.edu/static/ReleaseNotes_CADD_v1.3.pdf 
-  For reference, the order of severity of the consequences can be found at https://grch37.ensembl.org/info/genome/variation/prediction/predicted_data.html 
+    /** Choose the variant annotation with the highest consScore to prioritize annotation of the most deleterious transcript.
+  All consequence terms in CADD annotations can be found at https://cadd.gs.washington.edu/static/ReleaseNotes_CADD_v1.3.pdf
+  For reference, the order of severity of the consequences can be found at https://grch37.ensembl.org/info/genome/variation/prediction/predicted_data.html
   */
-  annotationResponse.forEach(a => {
-    const annotation = annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`];
+    annotationResponse.forEach(a => {
+      const annotation = annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`];
 
-    if (!annotation || a.consScore > annotation.consScore) {
-      annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] = a;
-    }
-  });
+      if (!annotation || a.consScore > annotation.consScore) {
+        annotationKeys[`${a.alt}-${a.chrom}-${a.pos}-${a.ref}`] = a;
+      }
+    });
 
-  queryResponse.forEach(response => {
-    const key = `${response.variant.alt}-${response.variant.chromosome.replace(/chr/i, '')}-${
-      response.variant.start
-    }-${response.variant.ref}`;
+    queryResponse.forEach(response => {
+      const key = `${response.variant.alt}-${response.variant.chromosome.replace(/chr/i, '')}-${
+        response.variant.start
+      }-${response.variant.ref}`;
 
-    if (key in annotationKeys) {
-      /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-      const { aaAlt, aaPos, aaRef, cdnaPos, chrom, pos, alt, ref, ...rest } = annotationKeys[key];
-      response.variant.info = {
-        ...response.variant.info,
-        aaChange:
-          aaAlt &&
-          AMINO_ACID_MAPPING[aaAlt] &&
-          aaPos &&
-          aaPos !== 'NA' &&
-          aaRef &&
-          AMINO_ACID_MAPPING[aaRef]
-            ? `p.${AMINO_ACID_MAPPING[aaRef]}${aaPos}${
-                aaAlt === aaRef ? '=' : AMINO_ACID_MAPPING[aaAlt]
-              }`
-            : 'NA',
-        cdna: alt && cdnaPos && cdnaPos !== 'NA' && ref ? `c.${cdnaPos}${ref}>${alt}` : 'NA',
-        ...rest,
-      };
-    }
-  });
+      if (key in annotationKeys) {
+        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+        const { aaAlt, aaPos, aaRef, cdnaPos, chrom, pos, alt, ref, ...rest } = annotationKeys[key];
+        response.variant.info = {
+          ...response.variant.info,
+          aaChange:
+            aaAlt &&
+            AMINO_ACID_MAPPING[aaAlt] &&
+            aaPos &&
+            aaPos !== 'NA' &&
+            aaRef &&
+            AMINO_ACID_MAPPING[aaRef]
+              ? `p.${AMINO_ACID_MAPPING[aaRef]}${aaPos}${
+                  aaAlt === aaRef ? '=' : AMINO_ACID_MAPPING[aaAlt]
+                }`
+              : 'NA',
+          cdna: alt && cdnaPos && cdnaPos !== 'NA' && ref ? `c.${cdnaPos}${ref}>${alt}` : 'NA',
+          ...rest,
+        };
+      }
+    });
 
-  return queryResponse;
-};
+    return queryResponse;
+  }
+);
 
 export default annotate;

--- a/server/src/resolvers/getVariantsResolver/utils/annotateGnomad.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/annotateGnomad.ts
@@ -1,19 +1,20 @@
 import GnomadAnnotationModel from '../../../models/GnomadAnnotationModel';
 import getCoordinates from '../../../models/utils/getCoordinates';
 import { GnomadAnnotation, VariantQueryDataResult } from '../../../types';
+import { timeitAsync } from '../../../utils/timeit';
 
-const annotateGnomad = async (
-  queryResponse: VariantQueryDataResult[]
-): Promise<VariantQueryDataResult[]> => {
-  const annotationCoordinates = getCoordinates(queryResponse);
+const annotateGnomad = timeitAsync('annotateGnomad')(
+  async (queryResponse: VariantQueryDataResult[]): Promise<VariantQueryDataResult[]> => {
+    const annotationCoordinates = getCoordinates(queryResponse);
 
-  const annotations = await GnomadAnnotationModel.getAnnotations(
-    annotationCoordinates,
-    'gnomAD_GRCh37'
-  );
+    const annotations = await GnomadAnnotationModel.getAnnotations(
+      annotationCoordinates,
+      'gnomAD_GRCh37'
+    );
 
-  return annotate(queryResponse, annotations);
-};
+    return annotate(queryResponse, annotations);
+  }
+);
 
 export const annotate = (
   queryResponse: VariantQueryDataResult[],

--- a/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
+++ b/server/src/resolvers/getVariantsResolver/utils/liftOver.ts
@@ -2,6 +2,7 @@ import { promises } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
 import { AssemblyId, VariantQueryDataResult } from '../../../types';
+import { timeitAsync } from '../../../utils/timeit';
 const exec = require('util').promisify(require('child_process').exec);
 
 const createTmpFile = async () => {
@@ -23,71 +24,73 @@ const parseBedEnd = (bed: String) =>
     .filter(l => !!l && !l.startsWith('#'))
     .map(v => v.split('\t')[2]);
 
-const liftover = async (
-  dataForAnnotation: VariantQueryDataResult[],
-  dataForLiftover: VariantQueryDataResult[],
-  assemblyIdInput: AssemblyId
-) => {
-  // Convert variants from JSON format to BED format.
-  // Note that position format is 1-based and BED format is half-open 0-based: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
-  const bedstring = dataForLiftover
-    .map(v => `chr${v.variant.chromosome}\t${v.variant.start - 1}\t${v.variant.end}`)
-    .join('\n');
-  const lifted = await createTmpFile();
-  const unlifted = await createTmpFile();
-  const bedfile = await createTmpFile();
-  await promises.writeFile(bedfile, bedstring);
+const liftover = timeitAsync('liftover')(
+  async (
+    dataForAnnotation: VariantQueryDataResult[],
+    dataForLiftover: VariantQueryDataResult[],
+    assemblyIdInput: AssemblyId
+  ) => {
+    // Convert variants from JSON format to BED format.
+    // Note that position format is 1-based and BED format is half-open 0-based: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
+    const bedstring = dataForLiftover
+      .map(v => `chr${v.variant.chromosome}\t${v.variant.start - 1}\t${v.variant.end}`)
+      .join('\n');
+    const lifted = await createTmpFile();
+    const unlifted = await createTmpFile();
+    const bedfile = await createTmpFile();
+    await promises.writeFile(bedfile, bedstring);
 
-  let chain: string;
-  if (assemblyIdInput === 'GRCh37') {
-    chain = '/home/node/hg38ToHg19.over.chain';
-  } else {
-    chain = '/home/node/hg19ToHg38.over.chain';
-  }
-  await exec(`liftOver ${bedfile} ${chain} ${lifted} ${unlifted}`);
-  const _liftedVars = await promises.readFile(lifted);
-  const _unliftedVars = await promises.readFile(unlifted);
-  const liftedVars = parseBedStart(_liftedVars.toString());
-  const unliftedVars = parseBedStart(_unliftedVars.toString());
-  const liftedVarsEnd = parseBedEnd(_liftedVars.toString());
-
-  const unliftedMap: { [key: string]: boolean } = unliftedVars.reduce(
-    (acc, curr) => ({ ...acc, [curr]: true }),
-    {}
-  );
-  const unliftedVariants: VariantQueryDataResult[] = [];
-
-  // Merge lifted variants with dataForAnnotation. Filter unmapped variants.
-  dataForLiftover.forEach((v, i) => {
-    if (unliftedMap[(v.variant.start - 1).toString()]) {
-      v.variant.assemblyIdCurrent = v.variant.assemblyId;
-      unliftedVariants.push(v);
+    let chain: string;
+    if (assemblyIdInput === 'GRCh37') {
+      chain = '/home/node/hg38ToHg19.over.chain';
     } else {
-      v.variant.start = Number(liftedVars[i]) + 1; // Convert from BED format to position format.
-      v.variant.end = Number(liftedVarsEnd[i]);
-      v.variant.assemblyIdCurrent = assemblyIdInput;
-      dataForAnnotation.push(v);
+      chain = '/home/node/hg19ToHg38.over.chain';
     }
-  });
+    await exec(`liftOver ${bedfile} ${chain} ${lifted} ${unlifted}`);
+    const _liftedVars = await promises.readFile(lifted);
+    const _unliftedVars = await promises.readFile(unlifted);
+    const liftedVars = parseBedStart(_liftedVars.toString());
+    const unliftedVars = parseBedStart(_unliftedVars.toString());
+    const liftedVarsEnd = parseBedEnd(_liftedVars.toString());
 
-  // Compute the annotation position for the variants that are in user's requested assembly.
-  let geneStart = Infinity;
-  let geneEnd = 0;
-  dataForAnnotation.forEach(result => {
-    if (result.variant.start < geneStart) {
-      geneStart = result.variant.start;
-    }
-    if (result.variant.end > geneEnd) {
-      geneEnd = result.variant.end;
-    }
-  });
-  const annotationPosition = `${dataForAnnotation[0].variant.chromosome}:${geneStart}-${geneEnd}`;
+    const unliftedMap: { [key: string]: boolean } = unliftedVars.reduce(
+      (acc, curr) => ({ ...acc, [curr]: true }),
+      {}
+    );
+    const unliftedVariants: VariantQueryDataResult[] = [];
 
-  promises.rm(lifted);
-  promises.rm(unlifted);
-  promises.rm(bedfile);
+    // Merge lifted variants with dataForAnnotation. Filter unmapped variants.
+    dataForLiftover.forEach((v, i) => {
+      if (unliftedMap[(v.variant.start - 1).toString()]) {
+        v.variant.assemblyIdCurrent = v.variant.assemblyId;
+        unliftedVariants.push(v);
+      } else {
+        v.variant.start = Number(liftedVars[i]) + 1; // Convert from BED format to position format.
+        v.variant.end = Number(liftedVarsEnd[i]);
+        v.variant.assemblyIdCurrent = assemblyIdInput;
+        dataForAnnotation.push(v);
+      }
+    });
 
-  return { dataForAnnotation, unliftedVariants, annotationPosition };
-};
+    // Compute the annotation position for the variants that are in user's requested assembly.
+    let geneStart = Infinity;
+    let geneEnd = 0;
+    dataForAnnotation.forEach(result => {
+      if (result.variant.start < geneStart) {
+        geneStart = result.variant.start;
+      }
+      if (result.variant.end > geneEnd) {
+        geneEnd = result.variant.end;
+      }
+    });
+    const annotationPosition = `${dataForAnnotation[0].variant.chromosome}:${geneStart}-${geneEnd}`;
+
+    promises.rm(lifted);
+    promises.rm(unlifted);
+    promises.rm(bedfile);
+
+    return { dataForAnnotation, unliftedVariants, annotationPosition };
+  }
+);
 
 export default liftover;

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -1,0 +1,76 @@
+// Wrapper factory functions for logging the execution time of functions.
+
+import logger from '../logger';
+
+type AnyFunction = (...args: any[]) => any;
+
+interface TimeitOptions {
+  precision?: number;
+}
+
+const DEFAULT_TIMEIT_OPTIONS: TimeitOptions = {
+  precision: 4,
+};
+
+const formatExecTime = (
+  execTime: [number, number],
+  name: string,
+  options: TimeitOptions
+): string => {
+  const logString = `[${name}] t: ${execTime[0].toLocaleString()}${
+    options && options.precision && options.precision > 0
+      ? `.${execTime[1].toLocaleString().substring(0, options.precision)}`
+      : ''
+  }`;
+  return logString;
+};
+
+/**
+ * Return a wrapper function that logs the execution time of a function it wraps.
+ *
+ * The parameter and return types of the original function are preserved in the
+ * wrapped function.
+ *
+ * @example
+ * const slow_function = (num: number): number => {
+ *   // ...
+ *   return num + 1;
+ * };
+ * const wrapped_slow_function = timeit("slow_function")(slow_function);  // wrapped_slow_function: (number) => number
+ * wrapped_slow_function(0);  // returns 1
+ * @param name Optional name to log alongside the function execution time.
+ * @param options Other factory options, see TimeitOptions interface
+ */
+export const timeit = (name?: string, options?: TimeitOptions) => {
+  // Executes when the factory is called and the wrapper is created.
+  const _options: TimeitOptions = {
+    ...DEFAULT_TIMEIT_OPTIONS,
+    ...options,
+  };
+
+  // https://stackoverflow.com/a/61212868
+  return <Func extends AnyFunction>(
+    func: Func
+  ): ((...args: Parameters<Func>) => ReturnType<Func>) => {
+    // Executes when a function is wrapped.
+    const _name = name ? name : func.name;
+
+    const wrapped_func = (...args: Parameters<Func>): ReturnType<Func> => {
+      // Executes when the wrapped function is called.
+      const t = process.hrtime();
+      var result: ReturnType<Func>; // original function
+      try {
+        result = func(...args);
+      } catch (error) {
+        const execTime = process.hrtime(t);
+        logger.error(formatExecTime(execTime, _name, _options));
+        throw error;
+      }
+      const execTime = process.hrtime(t);
+      logger.debug(formatExecTime(execTime, _name, _options));
+      return result;
+    };
+
+    return wrapped_func;
+  };
+};

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -13,7 +13,7 @@ const DEFAULT_TIMEIT_OPTIONS: TimeitOptions = {
   precision: 4,
 };
 
-var timeitDepth = 0;
+let timeitDepth = 0;
 
 const formatExecTime = (
   execTime: [number, number],
@@ -60,7 +60,7 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
     const wrapped_func = (...args: Parameters<Func>): ReturnType<Func> => {
       const t = process.hrtime();
       timeitDepth += 1;
-      var result: ReturnType<Func>;
+      let result: ReturnType<Func>;
       try {
         result = func(...args); // call original function
       } catch (error) {
@@ -120,7 +120,7 @@ export const timeitAsync = (name?: string, options?: TimeitOptions) => {
     const wrapped_func = async (...args: Parameters<AsyncFunc>): ReturnType<AsyncFunc> => {
       const t = process.hrtime();
       timeitDepth += 1;
-      var result: ReturnType<AsyncFunc>;
+      let result: ReturnType<AsyncFunc>;
       try {
         result = await func(...args); // call original function
       } catch (error) {

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -13,6 +13,8 @@ const DEFAULT_TIMEIT_OPTIONS: TimeitOptions = {
   precision: 4,
 };
 
+var timeitDepth = 0;
+
 const formatExecTime = (
   execTime: [number, number],
   name: string,
@@ -23,7 +25,7 @@ const formatExecTime = (
     options && options.precision && options.precision > 0
       ? `.${execTime[1].toString().substring(0, options.precision)}`
       : ''
-  }s`;
+  }s (depth: ${timeitDepth})`;
   return logString;
 };
 
@@ -57,16 +59,19 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
 
     const wrapped_func = (...args: Parameters<Func>): ReturnType<Func> => {
       const t = process.hrtime();
+      timeitDepth += 1;
       var result: ReturnType<Func>;
       try {
         result = func(...args); // call original function
       } catch (error) {
         const execTime = process.hrtime(t);
         logger.error(formatExecTime(execTime, _name, _options));
+        timeitDepth -= 1;
         throw error;
       }
       const execTime = process.hrtime(t);
       logger.debug(formatExecTime(execTime, _name, _options));
+      timeitDepth -= 1;
       return result;
     };
 
@@ -115,16 +120,19 @@ export const timeitAsync = (name?: string, options?: TimeitOptions) => {
     // @ts-ignore: ts(1064)
     const wrapped_func = async (...args: Parameters<AsyncFunc>): ReturnType<AsyncFunc> => {
       const t = process.hrtime();
+      timeitDepth += 1;
       var result: ReturnType<AsyncFunc>;
       try {
         result = await func(...args); // call original function
       } catch (error) {
         const execTime = process.hrtime(t);
         logger.error(formatExecTime(execTime, _name, _options, true));
+        timeitDepth -= 1;
         throw error;
       }
       const execTime = process.hrtime(t);
       logger.debug(formatExecTime(execTime, _name, _options, true));
+      timeitDepth -= 1;
       return result;
     };
 

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -3,6 +3,7 @@
 import logger from '../logger';
 
 type AnyFunction = (...args: any[]) => any;
+type AnyAsyncFunction = (...args: any[]) => Promise<any>;
 
 interface TimeitOptions {
   precision?: number;
@@ -15,9 +16,10 @@ const DEFAULT_TIMEIT_OPTIONS: TimeitOptions = {
 const formatExecTime = (
   execTime: [number, number],
   name: string,
-  options: TimeitOptions
+  options: TimeitOptions,
+  async?: boolean
 ): string => {
-  const logString = `[${name}] t: ${execTime[0].toLocaleString()}${
+  const logString = `[${async ? 'async ' : ''}${name}] exec_time: ${execTime[0].toLocaleString()}${
     options && options.precision && options.precision > 0
       ? `.${execTime[1].toLocaleString().substring(0, options.precision)}`
       : ''
@@ -36,31 +38,28 @@ const formatExecTime = (
  *   // ...
  *   return num + 1;
  * };
- * const wrapped_slow_function = timeit("slow_function")(slow_function);  // wrapped_slow_function: (number) => number
+ * const wrapped_slow_function = timeit("slow")(slow_function);  // wrapped_slow_function: (number) => number
  * wrapped_slow_function(0);  // returns 1
  * @param name Optional name to log alongside the function execution time.
  * @param options Other factory options, see TimeitOptions interface
  */
 export const timeit = (name?: string, options?: TimeitOptions) => {
-  // Executes when the factory is called and the wrapper is created.
   const _options: TimeitOptions = {
     ...DEFAULT_TIMEIT_OPTIONS,
     ...options,
   };
 
-  // https://stackoverflow.com/a/61212868
-  return <Func extends AnyFunction>(
+  // https://stackoverflow.com/a/61212868 to preserve function type
+  const timeit_wrapper = <Func extends AnyFunction>(
     func: Func
   ): ((...args: Parameters<Func>) => ReturnType<Func>) => {
-    // Executes when a function is wrapped.
     const _name = name ? name : func.name;
 
     const wrapped_func = (...args: Parameters<Func>): ReturnType<Func> => {
-      // Executes when the wrapped function is called.
       const t = process.hrtime();
-      var result: ReturnType<Func>; // original function
+      var result: ReturnType<Func>;
       try {
-        result = func(...args);
+        result = func(...args); // call original function
       } catch (error) {
         const execTime = process.hrtime(t);
         logger.error(formatExecTime(execTime, _name, _options));
@@ -73,4 +72,64 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
 
     return wrapped_func;
   };
+
+  return timeit_wrapper;
+};
+
+/**
+ * Return a wrapper function that logs the execution time of
+ * an asynchronous function that it wraps.
+ *
+ * "Execution time" is considered the combined time it takes for
+ * the original function to return a Promise, and for that Promise
+ * to resolve.
+ *
+ * The parameter and return types of the original function are preserved in the
+ * wrapped function.
+ *
+ * @example
+ * const slow_function = (num: number): number => {
+ *   // ...
+ *   return num + 1;
+ * };
+ * const wrapped_slow_function = timeit("slow")(slow_function);  // wrapped_slow_function: (number) => number
+ * wrapped_slow_function(0);  // returns 1
+ * @param name Optional name to log alongside the function execution time.
+ * @param options Other factory options, see TimeitOptions interface
+ */
+export const timeitAsync = (name?: string, options?: TimeitOptions) => {
+  const _options: TimeitOptions = {
+    ...DEFAULT_TIMEIT_OPTIONS,
+    ...options,
+  };
+
+  // https://stackoverflow.com/a/61212868 to preserve function type
+  const timeit_wrapper = <AsyncFunc extends AnyAsyncFunction>(
+    func: AsyncFunc
+  ): ((...args: Parameters<AsyncFunc>) => ReturnType<AsyncFunc>) => {
+    const _name = name ? name : func.name;
+
+    // TS expects wrapped_func to have return type Promise<T>,
+    // but it's implied by ReturnType<AsyncFunc>
+    // And we also don't use any weird custom promises https://github.com/microsoft/TypeScript/issues/35191#issuecomment-557230996
+    // @ts-ignore: ts(1064)
+    const wrapped_func = async (...args: Parameters<AsyncFunc>): ReturnType<AsyncFunc> => {
+      const t = process.hrtime();
+      var result: ReturnType<AsyncFunc>;
+      try {
+        result = await func(...args); // call original function
+      } catch (error) {
+        const execTime = process.hrtime(t);
+        logger.error(formatExecTime(execTime, _name, _options, true));
+        throw error;
+      }
+      const execTime = process.hrtime(t);
+      logger.debug(formatExecTime(execTime, _name, _options, true));
+      return result;
+    };
+
+    return wrapped_func;
+  };
+
+  return timeit_wrapper;
 };

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -93,12 +93,11 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
  * wrapped function.
  *
  * @example
- * const slow_function = (num: number): number => {
- *   // ...
- *   return num + 1;
+ * const slow_function = async (num: number): number => {
+ *   return setTimeout(() => num + 1, 1e5);
  * };
- * const wrapped_slow_function = timeit("slow")(slow_function);  // wrapped_slow_function: (number) => number
- * wrapped_slow_function(0);  // returns 1
+ * const wrapped_slow_function = timeitAsync("slow")(slow_function);  // wrapped_slow_function: async (number) => number
+ * wrapped_slow_function(0).then(alert);  // alerts 1
  * @param name Optional name to log alongside the function execution time.
  * @param options Other factory options, see TimeitOptions interface
  */

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -21,7 +21,7 @@ const formatExecTime = (
   options: TimeitOptions,
   async?: boolean
 ): string => {
-  const logString = `[${async ? 'async ' : ''}${name}] ${execTime[0].toLocaleString()}${
+  const logString = `[${async ? 'async ' : ''}${name + ''}] ${execTime[0].toLocaleString()}${
     options && options.precision && options.precision > 0
       ? `.${execTime[1].toString().substring(0, options.precision)}`
       : ''
@@ -52,12 +52,12 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
   };
 
   // https://stackoverflow.com/a/61212868 to preserve function type
-  const timeit_wrapper = <Func extends AnyFunction>(
+  const timeitWrapper = <Func extends AnyFunction>(
     func: Func
   ): ((...args: Parameters<Func>) => ReturnType<Func>) => {
-    const _name = name ? name : func.name ? func.name : 'undefined';
+    const _name = name || func.name;
 
-    const wrapped_func = (...args: Parameters<Func>): ReturnType<Func> => {
+    const wrappedFunc = (...args: Parameters<Func>): ReturnType<Func> => {
       const t = process.hrtime();
       timeitDepth += 1;
       let result: ReturnType<Func>;
@@ -75,10 +75,10 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
       return result;
     };
 
-    return wrapped_func;
+    return wrappedFunc;
   };
 
-  return timeit_wrapper;
+  return timeitWrapper;
 };
 
 /**
@@ -108,16 +108,16 @@ export const timeitAsync = (name?: string, options?: TimeitOptions) => {
   };
 
   // https://stackoverflow.com/a/61212868 to preserve function type
-  const timeit_wrapper = <AsyncFunc extends AnyAsyncFunction>(
+  const timeitWrapper = <AsyncFunc extends AnyAsyncFunction>(
     func: AsyncFunc
   ): ((...args: Parameters<AsyncFunc>) => ReturnType<AsyncFunc>) => {
-    const _name = name ? name : func.name ? func.name : 'undefined';
+    const _name = name || func.name;
 
-    // TS expects wrapped_func to have return type Promise<T>,
+    // TS expects wrappedFunc to have return type Promise<T>,
     // but it's implied by ReturnType<AsyncFunc>
     // And we also don't use any weird custom promises https://github.com/microsoft/TypeScript/issues/35191#issuecomment-557230996
     // @ts-ignore: ts(1064)
-    const wrapped_func = async (...args: Parameters<AsyncFunc>): ReturnType<AsyncFunc> => {
+    const wrappedFunc = async (...args: Parameters<AsyncFunc>): ReturnType<AsyncFunc> => {
       const t = process.hrtime();
       timeitDepth += 1;
       let result: ReturnType<AsyncFunc>;
@@ -135,8 +135,8 @@ export const timeitAsync = (name?: string, options?: TimeitOptions) => {
       return result;
     };
 
-    return wrapped_func;
+    return wrappedFunc;
   };
 
-  return timeit_wrapper;
+  return timeitWrapper;
 };

--- a/server/src/utils/timeit.ts
+++ b/server/src/utils/timeit.ts
@@ -6,7 +6,7 @@ type AnyFunction = (...args: any[]) => any;
 type AnyAsyncFunction = (...args: any[]) => Promise<any>;
 
 interface TimeitOptions {
-  precision?: number;
+  precision?: number; // between 0 and 9; number of decimal places for time
 }
 
 const DEFAULT_TIMEIT_OPTIONS: TimeitOptions = {
@@ -19,11 +19,11 @@ const formatExecTime = (
   options: TimeitOptions,
   async?: boolean
 ): string => {
-  const logString = `[${async ? 'async ' : ''}${name}] exec_time: ${execTime[0].toLocaleString()}${
+  const logString = `[${async ? 'async ' : ''}${name}] ${execTime[0].toLocaleString()}${
     options && options.precision && options.precision > 0
-      ? `.${execTime[1].toLocaleString().substring(0, options.precision)}`
+      ? `.${execTime[1].toString().substring(0, options.precision)}`
       : ''
-  }`;
+  }s`;
   return logString;
 };
 
@@ -53,7 +53,7 @@ export const timeit = (name?: string, options?: TimeitOptions) => {
   const timeit_wrapper = <Func extends AnyFunction>(
     func: Func
   ): ((...args: Parameters<Func>) => ReturnType<Func>) => {
-    const _name = name ? name : func.name;
+    const _name = name ? name : func.name ? func.name : 'undefined';
 
     const wrapped_func = (...args: Parameters<Func>): ReturnType<Func> => {
       const t = process.hrtime();
@@ -107,7 +107,7 @@ export const timeitAsync = (name?: string, options?: TimeitOptions) => {
   const timeit_wrapper = <AsyncFunc extends AnyAsyncFunction>(
     func: AsyncFunc
   ): ((...args: Parameters<AsyncFunc>) => ReturnType<AsyncFunc>) => {
-    const _name = name ? name : func.name;
+    const _name = name ? name : func.name ? func.name : 'undefined';
 
     // TS expects wrapped_func to have return type Promise<T>,
     // but it's implied by ReturnType<AsyncFunc>


### PR DESCRIPTION
Adds `timeit` and `timeitAsync` functions for logging execution time of functions.

EDIT: A lot of the diffs outside of `timeit.ts` are mostly whitespace. The GitHub diff viewer has a setting to hide whitespace which will highlight only the actual text changes.