### PR TITLE
"Deploy" job only runs when the workflow is against a specific branch

### DIFF
--- a/.github/workflows/node-prod.yml
+++ b/.github/workflows/node-prod.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: [cheo-ri]
     needs:
       - build-server
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/production'
     environment: OSMP_PROD
     concurrency: OSMP_PROD
     steps:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -119,7 +119,7 @@ jobs:
     needs:
       - build-server
       - build-test-node
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/develop'
     environment: SSMP_SERVER_DEV
     concurrency: SSMP_SERVER_DEV
     steps:

--- a/.github/workflows/react-prod.yml
+++ b/.github/workflows/react-prod.yml
@@ -67,7 +67,7 @@ jobs:
     needs: build-react
     environment: OSMP_PROD
     concurrency: OSMP_PROD
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/production'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -56,7 +56,7 @@ jobs:
     needs: build-react
     environment: SSMP_BUILD
     concurrency: SSMP_BUILD
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
The "Deploy" stage should run when there is a push to `develop` or `production` and when we manually run a worflow. Thus, the  "Deploy" stage's trigger condition has been changed from "on push event" to "on which branch is targeted". 