### PR TITLE
Server: Fix memory leaks in express-session 

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "graphql": "^16.3.0",
     "jwt-decode": "^3.1.2",
     "keycloak-connect": "17.0.0",
+    "memorystore": "^1.6.7",
     "mongoose": "^6.0.8",
     "node-cache": "^5.1.2",
     "subscriptions-transport-ws": "^0.11.0",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -16,7 +16,7 @@ import memorystore from 'memorystore';
 
 const app = express();
 
-const memoryStore = memorystore(session);
+const MemoryStore = memorystore(session);
 
 mongoose
   .connect(process.env.MONGO_CONNECTION_STRING!)
@@ -33,7 +33,7 @@ app.use(
     secret: process.env.SERVER_SESSION_SECRET!,
     resave: false,
     saveUninitialized: true,
-    store: new memoryStore({
+    store: new MemoryStore({
       checkPeriod: 86400000, // prune expired entries every 24h
     }),
   })
@@ -41,7 +41,7 @@ app.use(
 
 const keycloak = new Keycloak(
   {
-    store: memoryStore,
+    store: MemoryStore,
   },
   {
     realm: process.env.KEYCLOAK_REALM!,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -17,6 +17,9 @@ import memorystore from 'memorystore';
 const app = express();
 
 const MemoryStore = memorystore(session);
+const memoryStore = new MemoryStore({
+  checkPeriod: 86400000, // prune expired entries every 24h
+});
 
 mongoose
   .connect(process.env.MONGO_CONNECTION_STRING!)
@@ -33,15 +36,13 @@ app.use(
     secret: process.env.SERVER_SESSION_SECRET!,
     resave: false,
     saveUninitialized: true,
-    store: new MemoryStore({
-      checkPeriod: 86400000, // prune expired entries every 24h
-    }),
+    store: memoryStore,
   })
 );
 
 const keycloak = new Keycloak(
   {
-    store: MemoryStore,
+    store: memoryStore,
   },
   {
     realm: process.env.KEYCLOAK_REALM!,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,10 +12,11 @@ import typeDefs from './typeDefs';
 import resolvers from './resolvers';
 import validateToken from './patches/validateToken';
 import mongoose from 'mongoose';
+import memorystore from 'memorystore';
 
 const app = express();
 
-const memoryStore = new session.MemoryStore();
+const memoryStore = memorystore(session);
 
 mongoose
   .connect(process.env.MONGO_CONNECTION_STRING!)
@@ -32,7 +33,9 @@ app.use(
     secret: process.env.SERVER_SESSION_SECRET!,
     resave: false,
     saveUninitialized: true,
-    store: memoryStore,
+    store: new memoryStore({
+      checkPeriod: 86400000, // prune expired entries every 24h
+    }),
   })
 );
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2080,7 +2080,7 @@ debug@2.6.9, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.3.4, debug@4.x, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
+debug@4, debug@4.3.4, debug@4.x, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4061,6 +4061,14 @@ long@^5.1.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
   integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
+lru-cache@^4.0.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -4096,6 +4104,14 @@ memory-pager@^1.0.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
   integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
+memorystore@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/memorystore/-/memorystore-1.6.7.tgz#78f9b1c2b06949abfb4f85ec71f558ec4265e63d"
+  integrity sha512-OZnmNY/NDrKohPQ+hxp0muBcBKrzKNtHr55DbqSx9hLsYVNnomSAMRAtI7R64t3gf3ID7tHQA7mG4oL3Hu9hdw==
+  dependencies:
+    debug "^4.3.0"
+    lru-cache "^4.0.3"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -4604,6 +4620,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.33:
   version "1.8.0"
@@ -5634,6 +5655,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
When `server` container is deployed to production, this error is encountered: 
"Warning The default server-side session storage, MemoryStore, is purposely not designed for a production environment. It will leak memory under most conditions, does not scale past a single process, and is meant for debugging and developing."

Among a list of compatible session stores for `express-session`, I have chosen [`memorystore`](https://www.npmjs.com/package/memorystore)  for its ability to avoid memory leaks. 