### PR TITLE
React / API: Add "observed" field for phenotypic features

### DIFF
--- a/react/src/apollo/hooks/useFetchVariantsQuery.ts
+++ b/react/src/apollo/hooks/useFetchVariantsQuery.ts
@@ -78,6 +78,7 @@ const fetchVariantsQuery = gql`
                         onsetType
                         phenotypeId
                         phenotypeLabel
+                        observed
                     }
                     sex
                 }

--- a/react/src/components/Table/CellViewer.tsx
+++ b/react/src/components/Table/CellViewer.tsx
@@ -7,6 +7,7 @@ import { CellText } from './Table.styles';
 export interface ViewerProps {
     rowExpanded: boolean;
     toggleRowExpanded: (value?: boolean) => void;
+    color?: string;
 }
 
 interface ItemName {
@@ -32,7 +33,7 @@ const Text = styled(props => <CellText {...props} />)`
     white-space: break-spaces;
     cursor: pointer;
     text-decoration: underline dotted;
-    color: blue;
+    color: ${props => props.color || 'blue'};
 `;
 
 const CellViewer = <T extends {}>({
@@ -42,6 +43,7 @@ const CellViewer = <T extends {}>({
     rowExpanded,
     toggleRowExpanded,
     text,
+    color,
 }: CellViewerProps<T>) => {
     const [cellExpanded, setCellExpanded] = useState<boolean>(false);
 
@@ -57,7 +59,7 @@ const CellViewer = <T extends {}>({
             <>
                 {items.map((item, index) => (
                     <React.Fragment key={index}>
-                        <Text onClick={onClick}>
+                        <Text onClick={onClick} color={color}>
                             {!!formatItemText ? formatItemText(item) : item}
                         </Text>
                         {!isLastElement(index, items) && <CellBorder />}
@@ -65,7 +67,7 @@ const CellViewer = <T extends {}>({
                 ))}
             </>
         ) : (
-            <Text onClick={onClick}>{`${items.length} ${
+            <Text onClick={onClick} color={color}>{`${items.length} ${
                 items.length === 1 ? singular : plural ?? `${singular}s`
             }`}</Text>
         );

--- a/react/src/components/Table/PhenotypeViewer.tsx
+++ b/react/src/components/Table/PhenotypeViewer.tsx
@@ -15,7 +15,10 @@ const PhenotypeViewer: React.FC<PhenotypeViewerProps> = ({
     return (
         <CellViewer<PhenotypicFeaturesFields>
             {...{ rowExpanded, toggleRowExpanded }}
-            formatItemText={phenotype => phenotype.phenotypeLabel || ''}
+            formatItemText={phenotype => {
+                const prefix = phenotype.observed === false ? 'NO ' : 'YES ';
+                return phenotype.phenotypeLabel ? prefix + phenotype.phenotypeLabel : '';
+            }}
             itemName={{ singular: 'Phenotype' }}
             items={phenotypes}
         />

--- a/react/src/components/Table/PhenotypeViewer.tsx
+++ b/react/src/components/Table/PhenotypeViewer.tsx
@@ -11,6 +11,7 @@ const PhenotypeViewer: React.FC<PhenotypeViewerProps> = ({
     phenotypes,
     rowExpanded,
     toggleRowExpanded,
+    color,
 }) => {
     return (
         <CellViewer<PhenotypicFeaturesFields>
@@ -21,6 +22,7 @@ const PhenotypeViewer: React.FC<PhenotypeViewerProps> = ({
             }}
             itemName={{ singular: 'Phenotype' }}
             items={phenotypes}
+            color={color}
         />
     );
 };

--- a/react/src/components/Table/PhenotypeViewer.tsx
+++ b/react/src/components/Table/PhenotypeViewer.tsx
@@ -16,10 +16,7 @@ const PhenotypeViewer: React.FC<PhenotypeViewerProps> = ({
     return (
         <CellViewer<PhenotypicFeaturesFields>
             {...{ rowExpanded, toggleRowExpanded }}
-            formatItemText={phenotype => {
-                const prefix = phenotype.observed === false ? 'NO ' : 'YES ';
-                return phenotype.phenotypeLabel ? prefix + phenotype.phenotypeLabel : '';
-            }}
+            formatItemText={phenotype => phenotype.phenotypeLabel || ''}
             itemName={{ singular: 'Phenotype' }}
             items={phenotypes}
             color={color}

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -457,6 +457,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                 {...{ toggleRowExpanded }}
                                 phenotypes={phenotypicFeatures?.filter(p => !p.observed)}
                                 rowExpanded={isExpanded}
+                                color={'red'}
                             />
                         ),
                     },

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -457,7 +457,7 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                                 {...{ toggleRowExpanded }}
                                 phenotypes={phenotypicFeatures?.filter(p => !p.observed)}
                                 rowExpanded={isExpanded}
-                                color={'red'}
+                                color="red"
                             />
                         ),
                     },

--- a/react/src/components/Table/Table.tsx
+++ b/react/src/components/Table/Table.tsx
@@ -409,10 +409,13 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                     {
                         accessor: state =>
                             state.phenotypicFeatures
-                                ? state.phenotypicFeatures.map(p => p.phenotypeLabel).join(', ')
+                                ? state.phenotypicFeatures
+                                      .filter(p => p.observed)
+                                      .map(p => p.phenotypeLabel)
+                                      .join(', ')
                                 : '',
-                        id: 'phenotypicFeatures',
-                        Header: 'Phenotypes',
+                        id: 'phenotypicFeaturesPresent',
+                        Header: 'Present Phenotypes',
                         width: 150,
                         Cell: ({
                             row: {
@@ -425,7 +428,34 @@ const Table: React.FC<TableProps> = ({ variantData }) => {
                         }) => (
                             <PhenotypeViewer
                                 {...{ toggleRowExpanded }}
-                                phenotypes={phenotypicFeatures}
+                                phenotypes={phenotypicFeatures?.filter(p => p.observed)}
+                                rowExpanded={isExpanded}
+                            />
+                        ),
+                    },
+                    {
+                        accessor: state =>
+                            state.phenotypicFeatures
+                                ? state.phenotypicFeatures
+                                      .filter(p => !p.observed)
+                                      .map(p => p.phenotypeLabel)
+                                      .join(', ')
+                                : '',
+                        id: 'phenotypicFeaturesAbsent',
+                        Header: 'Absent Phenotypes',
+                        width: 150,
+                        Cell: ({
+                            row: {
+                                isExpanded,
+                                original: { phenotypicFeatures },
+                                toggleRowExpanded,
+                            },
+                        }: {
+                            row: Row<ResultTableColumns>;
+                        }) => (
+                            <PhenotypeViewer
+                                {...{ toggleRowExpanded }}
+                                phenotypes={phenotypicFeatures?.filter(p => !p.observed)}
                                 rowExpanded={isExpanded}
                             />
                         ),

--- a/react/src/types.ts
+++ b/react/src/types.ts
@@ -57,6 +57,7 @@ export interface PhenotypicFeaturesFields {
     onsetType?: Maybe<string>;
     phenotypeId?: Maybe<string>;
     phenotypeLabel?: Maybe<string>;
+    observed?: Maybe<boolean>;
 }
 
 export interface DiseaseFields {

--- a/server/__tests__/adapters/g4rdAdapter.test.ts
+++ b/server/__tests__/adapters/g4rdAdapter.test.ts
@@ -186,6 +186,7 @@ describe('Test g4rd query response transformer', () => {
             individualId
             phenotypicFeatures {
               levelSeverity
+              observed
               phenotypeId
             }
             sex

--- a/server/__tests__/adapters/localQueryAdapter.test.ts
+++ b/server/__tests__/adapters/localQueryAdapter.test.ts
@@ -31,6 +31,7 @@ describe('Test local query adapter', () => {
               levelSeverity: 'high',
               onsetType: '3',
               phenotypeId: '4',
+              observed: true,
             })),
         },
         variant: {

--- a/server/__tests__/gql/getVariants.test.ts
+++ b/server/__tests__/gql/getVariants.test.ts
@@ -70,6 +70,7 @@ describe('Test minimal getVariants query', () => {
               levelSeverity
               onsetType
               phenotypeId
+              observed
             }
             sex
           }

--- a/server/src/resolvers/getVariantsResolver/adapters/localQueryAdapter.ts
+++ b/server/src/resolvers/getVariantsResolver/adapters/localQueryAdapter.ts
@@ -63,6 +63,7 @@ export const transformLocalQueryResponse: ResultTransformer<LocalQueryResponse[]
             levelSeverity: 'high',
             onsetType: '3',
             phenotypeId: '4',
+            observed: true,
           })),
       },
       variant: {

--- a/server/src/typeDefs.ts
+++ b/server/src/typeDefs.ts
@@ -61,6 +61,7 @@ export default gql`
     onsetType: String
     phenotypeId: String
     phenotypeLabel: String
+    observed: Boolean
   }
 
   type Disorder {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -58,6 +58,7 @@ export interface PhenotypicFeaturesFields {
   onsetType?: Maybe<string>;
   phenotypeId?: Maybe<string>;
   phenotypeLabel?: Maybe<string>;
+  observed?: Maybe<boolean>;
 }
 
 export interface DiseaseFields {
@@ -198,6 +199,7 @@ export interface Feature {
   qualifiers?: FeatureQualifier[];
 }
 export interface NonStandardFeature {
+  id?: undefined; // does not occur; used for type guarding
   label?: string;
   categories?: { id?: string; label?: string }[];
   type?: string; // "should be 'phenotype'"

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -148,6 +148,7 @@ export interface G4RDVariantQueryResult {
 }
 
 /* G4RD GET patients endpoint schema */
+// https://docs.phenotips.com/reference/fetchpatients-1
 export interface Contact {
   institution?: string;
   name?: string;
@@ -176,6 +177,32 @@ export interface Notes {
 export interface Solved {
   status: 'solved' | 'unsolved' | '';
 }
+export interface FeatureQualifier {
+  id?: string;
+  label?: string;
+  type?: // these types are the "accepted options" according to the docs
+  | 'age_of_onset'
+    | 'laterality'
+    | 'pace_of_progression'
+    | 'severity'
+    | 'spatial_pattern'
+    | 'temporal_pattern'
+    | string;
+}
+export interface Feature {
+  id?: string;
+  label?: string;
+  type?: string; // "should be 'phenotype'"
+  observed?: string; // may be 'yes' or 'no' or empty
+  notes?: string;
+  qualifiers?: FeatureQualifier[];
+}
+export interface NonStandardFeature {
+  label?: string;
+  categories?: { id?: string; label?: string }[];
+  type?: string; // "should be 'phenotype'"
+  observed?: string; // may be 'yes' or 'no' or empty
+}
 export interface G4RDPatientQueryResult {
   notes: Notes;
   ethnicity: Ethnicity;
@@ -184,6 +211,8 @@ export interface G4RDPatientQueryResult {
   id: string;
   genes?: Gene[];
   solved?: Solved;
+  features?: Feature[];
+  nonstandard_features?: NonStandardFeature[];
 }
 
 /* End of G4RD GET patients endpoint schema */

--- a/ssmp-schema.yml
+++ b/ssmp-schema.yml
@@ -122,6 +122,10 @@ components:
                       todo
                     type: string
                     example: "Xxx"
+                  observed:
+                    description: |
+                      Whether the phenotypic feature was observed or not.
+                    type: boolean
         sex:
           description: |
             Sex of the individual.


### PR DESCRIPTION
Closes #312 

Frontend now shows "YES X" or "NO X" for Phenotypes to indicate whether a phenotype was observed by a clinician.

Based on the results from PhenoTips, the logic is set up as follows:
```
observed field = "yes"  => true
observed field = "no"   => false
observed field missing  => true
```
We may need to verify with collaborators before pushing this to `develop`.