### PR TITLE
React: Allow users to fetch additional gene hits beyond the current default of 10

### DIFF
--- a/react/src/apollo/client.ts
+++ b/react/src/apollo/client.ts
@@ -1,5 +1,6 @@
 import { ApolloClient, createHttpLink, from, InMemoryCache, useLazyQuery } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
+import { relayStylePagination } from '@apollo/client/utilities';
 import { ApolloLink, QueryHookOptions, ServerError, useQuery } from '@apollo/react-hooks';
 import { RestLink } from 'apollo-link-rest';
 import ApolloLinkTimeout from 'apollo-link-timeout';
@@ -86,7 +87,15 @@ export const buildLink = (token?: string) => {
 
 export const client = new ApolloClient<any>({
     link: buildLink(),
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({
+        typePolicies: {
+            Query: {
+                fields: {
+                    autocompleteResults: relayStylePagination(),
+                },
+            },
+        },
+    }),
     defaultOptions: {
         watchQuery: {
             nextFetchPolicy: 'cache-only',

--- a/react/src/apollo/hooks/useFetchAutocompleteQuery.ts
+++ b/react/src/apollo/hooks/useFetchAutocompleteQuery.ts
@@ -5,11 +5,11 @@ import { useLazyApolloQuery } from '../client';
     fetch autocomplete results with ensembl id and genomic position 
 */
 const autocompleteQuery = gql`
-    query FetchAutocomplete($q: String) {
-        autocompleteResults(q: $q)
+    query FetchAutocomplete($q: String, $size: Number) {
+        autocompleteResults(q: $q, size: $size)
             @rest(
                 type: "AutoCompleteSuggestion"
-                path: "query?species=human&fields=genomic_pos_hg19,symbol,genomic_pos,ensembl.gene&{args}"
+                path: "query?species=human&fields=genomic_pos_hg19,symbol,genomic_pos,ensembl.gene&size={args.size}&q={args.q}"
             ) {
             hits {
                 symbol
@@ -27,6 +27,7 @@ const autocompleteQuery = gql`
                     start
                 }
             }
+            total
         }
     }
 `;
@@ -49,9 +50,12 @@ const useFetchAutocompleteQuery = () =>
                         start: number;
                     };
                 }[];
+                total: number;
             };
         },
-        { q: string }
-    >(autocompleteQuery);
+        { q: string; size: number }
+    >(autocompleteQuery, {
+        notifyOnNetworkStatusChange: true,
+    });
 
 export default useFetchAutocompleteQuery;

--- a/react/src/components/SelectableList.tsx
+++ b/react/src/components/SelectableList.tsx
@@ -7,6 +7,10 @@ interface SelectableListWrapperProps {
     fullWidth?: boolean;
 }
 
+interface StyledListProps {
+    stickyHeader?: React.ReactNode;
+}
+
 export const SelectableListWrapper = styled.div<SelectableListWrapperProps>`
     position: absolute;
     top: 100%;
@@ -14,13 +18,13 @@ export const SelectableListWrapper = styled.div<SelectableListWrapperProps>`
     width: ${props => (props.fullWidth ? '100%' : 'fit-content')};
 `;
 
-const StyledList = styled.ul`
+const StyledList = styled.ul<StyledListProps>`
     box-shadow: ${props => props.theme.boxShadow};
     padding: 0;
     margin: 0;
     list-style-type: none;
     width: inherit;
-    max-height: 200px;
+    max-height: ${props => (props.stickyHeader ? '250' : '200')}px;
     overflow: auto;
 `;
 
@@ -72,12 +76,23 @@ interface ListProps<T> {
     onSelect: (val: T) => void;
     selection?: T[];
     options: SelectableListItem<T>[];
+    stickyHeader?: React.ReactNode;
 }
 
 function SelectableListInner<T>(props: ListProps<T>, ref: React.ForwardedRef<HTMLUListElement>) {
-    const { onSelect, options, isMulti, selection } = props;
+    const { onSelect, options, isMulti, selection, stickyHeader } = props;
     return (
-        <StyledList ref={ref}>
+        <StyledList {...{ ref, stickyHeader }}>
+            {stickyHeader && (
+                <StyledListItem
+                    style={{
+                        position: 'sticky',
+                        top: 0,
+                    }}
+                >
+                    {stickyHeader}
+                </StyledListItem>
+            )}
             {options.map((item, index) => {
                 if (!isMulti) {
                     return (


### PR DESCRIPTION
Currently, for the gene search autocomplete, OSMP is only querying for the first ten matching gene hits from the [mygene.info gene query service](https://docs.mygene.info/en/latest/doc/query_service.html#get-request) (the default when no value is provided to the `size` query parameter) with no option to allow the user to fetch additional gene hits.

This PR addresses this issue by adding a button to the gene autocomplete selectable list that allows users to fetch ten additional gene hits at a time.

**When there are additional gene hits to fetch:**
<img width="377" alt="Screen Shot 2022-08-17 at 3 17 09 PM" src="https://user-images.githubusercontent.com/39896715/185224295-3c4fef36-5f58-4a26-a26a-de197511d228.png">

**When all genes hits have been fetched:**
<img width="378" alt="Screen Shot 2022-08-17 at 3 18 50 PM" src="https://user-images.githubusercontent.com/39896715/185224599-429eda62-66eb-4485-be4a-8ced4d9e3a63.png">

Closes #313