### PR TITLE
CI/CD: Replace deprecated set-output in node workflows

### DIFF
--- a/.github/workflows/node-prod.yml
+++ b/.github/workflows/node-prod.yml
@@ -96,8 +96,8 @@ jobs:
           SSH_AGENT_EVAL=$(ssh-agent -s)
           eval "$SSH_AGENT_EVAL"
           ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
-          echo "::set-output name=ssh-agent-eval::$SSH_AGENT_EVAL"
-          echo "::set-output name=ssh-agent-pid::$SSH_AGENT_PID"
+          echo "ssh-agent-eval=$SSH_AGENT_EVAL" >> $GITHUB_OUTPUT
+          echo "ssh-agent-pid=$SSH_AGENT_PID" >> $GITHUB_OUTPUT
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod -R g-rwx,o-rwx ~/.ssh

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -141,8 +141,8 @@ jobs:
           SSH_AGENT_EVAL=$(ssh-agent -s)
           eval "$SSH_AGENT_EVAL"
           ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
-          echo "::set-output name=ssh-agent-eval::$SSH_AGENT_EVAL"
-          echo "::set-output name=ssh-agent-pid::$SSH_AGENT_PID"
+          echo "ssh-agent-eval=$SSH_AGENT_EVAL" >> $GITHUB_OUTPUT
+          echo "ssh-agent-pid=$SSH_AGENT_PID" >> $GITHUB_OUTPUT
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod -R g-rwx,o-rwx ~/.ssh

--- a/.github/workflows/react-prod.yml
+++ b/.github/workflows/react-prod.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: 16
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         id: yarn-cache
         with:
@@ -75,7 +75,7 @@ jobs:
           node-version: 16
       - name: Get yarn cache path
         id: yarn-cache-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         id: restore
         with:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 16
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         id: yarn-cache
         with:
@@ -64,7 +64,7 @@ jobs:
           node-version: 16
       - name: Get yarn cache path
         id: yarn-cache-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         id: restore
         with:


### PR DESCRIPTION
2nd attempt to replace deprecated ::set-output workflow actions. Key difference is using `>> $GITHUB_OUTPUT` instead of `>> "$GITHUB_OUTPUT"`, which should address issues with the first attempt at this issue.